### PR TITLE
Multiple GitHub url formats

### DIFF
--- a/cff_converter_python/citation.py
+++ b/cff_converter_python/citation.py
@@ -26,9 +26,9 @@ class Citation:
 
         regexp = re.compile("^" +
                             "(?P<baseurl>https://github\.com)/" +
-                            "(?P<user>[^/\n]*)/" +
+                            "(?P<org>[^/\n]*)/" +
                             "(?P<repo>[^/\n]*)" +
-                            "(/(?P<branch>[^/\n]*))?", re.IGNORECASE)
+                            "(/tree/(?P<label>[^/\n]*))?", re.IGNORECASE)
 
         matched = re.match(regexp, self.url)
         if matched is None:
@@ -38,9 +38,9 @@ class Citation:
             url_parts = matched.groupdict()
 
         self.file_url = "/".join([self.baseurl,
-                                  url_parts["user"],
+                                  url_parts["org"],
                                   url_parts["repo"],
-                                  url_parts["branch"] if url_parts["branch"] is not None else "master",
+                                  url_parts["label"] if url_parts["label"] is not None else "master",
                                   "CITATION.cff"])
 
         r = requests.get(self.file_url)

--- a/livetest/citation_test.py
+++ b/livetest/citation_test.py
@@ -6,7 +6,117 @@ from cff_converter_python import Citation
 class CitationTest1(unittest.TestCase):
 
     def setUp(self):
+        # https://github.com/<org>/<repo>
         url = "https://github.com/citation-file-format/cff-converter-python"
+        self.citation = Citation(url)
+
+    def test_printing_as_bibtex(self):
+        fixture = os.path.join("fixtures", "bibtex-1")
+        with open(fixture) as f:
+            expected_bibtex = f.read()
+        actual_bibtex = self.citation.as_bibtex()
+        self.assertEqual(expected_bibtex, actual_bibtex)
+
+    def test_printing_as_codemeta(self):
+        fixture = os.path.join("fixtures", "codemeta-1")
+        with open(fixture) as f:
+            expected_codemeta = f.read()
+        actual_codemeta = self.citation.as_codemeta()
+        self.assertEqual(expected_codemeta, actual_codemeta)
+
+    def test_printing_as_enw(self):
+        fixture = os.path.join("fixtures", "endnote-1")
+        with open(fixture) as f:
+            expected_endnote = f.read()
+        actual_endnote = self.citation.as_enw()
+        self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_ris(self):
+        fixture = os.path.join("fixtures", "ris-1")
+        with open(fixture) as f:
+            expected_ris = f.read()
+        actual_ris = self.citation.as_ris()
+        self.assertEqual(expected_ris, actual_ris)
+
+
+class CitationTest2(unittest.TestCase):
+
+    def setUp(self):
+        # https://github.com/<org>/<repo>/tree/<sha>
+        url = "https://github.com/citation-file-format/cff-converter-python/tree/" + \
+              "b7505591cf421ab33156ec0bffb0af43fd7d2cd1"
+        self.citation = Citation(url)
+
+    def test_printing_as_bibtex(self):
+        fixture = os.path.join("fixtures", "bibtex-1")
+        with open(fixture) as f:
+            expected_bibtex = f.read()
+        actual_bibtex = self.citation.as_bibtex()
+        self.assertEqual(expected_bibtex, actual_bibtex)
+
+    def test_printing_as_codemeta(self):
+        fixture = os.path.join("fixtures", "codemeta-1")
+        with open(fixture) as f:
+            expected_codemeta = f.read()
+        actual_codemeta = self.citation.as_codemeta()
+        self.assertEqual(expected_codemeta, actual_codemeta)
+
+    def test_printing_as_enw(self):
+        fixture = os.path.join("fixtures", "endnote-1")
+        with open(fixture) as f:
+            expected_endnote = f.read()
+        actual_endnote = self.citation.as_enw()
+        self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_ris(self):
+        fixture = os.path.join("fixtures", "ris-1")
+        with open(fixture) as f:
+            expected_ris = f.read()
+        actual_ris = self.citation.as_ris()
+        self.assertEqual(expected_ris, actual_ris)
+
+
+class CitationTest3(unittest.TestCase):
+
+    def setUp(self):
+        # https://github.com/<org>/<repo>/tree/<tagname>
+        url = "https://github.com/citation-file-format/cff-converter-python/tree/0.0.1"
+        self.citation = Citation(url)
+
+    def test_printing_as_bibtex(self):
+        fixture = os.path.join("fixtures", "bibtex-1")
+        with open(fixture) as f:
+            expected_bibtex = f.read()
+        actual_bibtex = self.citation.as_bibtex()
+        self.assertEqual(expected_bibtex, actual_bibtex)
+
+    def test_printing_as_codemeta(self):
+        fixture = os.path.join("fixtures", "codemeta-1")
+        with open(fixture) as f:
+            expected_codemeta = f.read()
+        actual_codemeta = self.citation.as_codemeta()
+        self.assertEqual(expected_codemeta, actual_codemeta)
+
+    def test_printing_as_enw(self):
+        fixture = os.path.join("fixtures", "endnote-1")
+        with open(fixture) as f:
+            expected_endnote = f.read()
+        actual_endnote = self.citation.as_enw()
+        self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_ris(self):
+        fixture = os.path.join("fixtures", "ris-1")
+        with open(fixture) as f:
+            expected_ris = f.read()
+        actual_ris = self.citation.as_ris()
+        self.assertEqual(expected_ris, actual_ris)
+
+
+class CitationTest4(unittest.TestCase):
+
+    def setUp(self):
+        # https://github.com/<org>/<repo>/tree/<branchname>
+        url = "https://github.com/citation-file-format/cff-converter-python/tree/master"
         self.citation = Citation(url)
 
     def test_printing_as_bibtex(self):

--- a/livetest/citation_test.py
+++ b/livetest/citation_test.py
@@ -3,7 +3,7 @@ import os
 from cff_converter_python import Citation
 
 
-class CitationTest1(unittest.TestCase):
+class CitationTestUrlHasOrgRepoOnly(unittest.TestCase):
 
     def setUp(self):
         # https://github.com/<org>/<repo>
@@ -39,7 +39,7 @@ class CitationTest1(unittest.TestCase):
         self.assertEqual(expected_ris, actual_ris)
 
 
-class CitationTest2(unittest.TestCase):
+class CitationTestUrlHasOrgRepoTreeSha(unittest.TestCase):
 
     def setUp(self):
         # https://github.com/<org>/<repo>/tree/<sha>
@@ -76,7 +76,7 @@ class CitationTest2(unittest.TestCase):
         self.assertEqual(expected_ris, actual_ris)
 
 
-class CitationTest3(unittest.TestCase):
+class CitationTestUrlHasOrgRepoOrgRepoTreeTag(unittest.TestCase):
 
     def setUp(self):
         # https://github.com/<org>/<repo>/tree/<tagname>
@@ -112,7 +112,7 @@ class CitationTest3(unittest.TestCase):
         self.assertEqual(expected_ris, actual_ris)
 
 
-class CitationTest4(unittest.TestCase):
+class CitationTestOrgRepoTreeBranch(unittest.TestCase):
 
     def setUp(self):
         # https://github.com/<org>/<repo>/tree/<branchname>


### PR DESCRIPTION
The tool used to only do github urls in the format
- ``https://github.com/<org>/<repo>``

With this PR , it now does urls in the formats
- ``https://github.com/<org>/<repo>``
- ``https://github.com/<org>/<repo>/tree/<sha>``
- ``https://github.com/<org>/<repo>/tree/<tagname>``
- ``https://github.com/<org>/<repo>/tree/<branchname>``

I also added livetests for each of the cases, pointing to the CFF of this repo.

