### PR TITLE
now able to override suspect keys like doi and date-released

### DIFF
--- a/cff_converter_python/citation.py
+++ b/cff_converter_python/citation.py
@@ -4,30 +4,40 @@ import re
 import json
 from datetime import datetime, date
 
+
 class JSONEncoder(json.JSONEncoder):
     def default(self, o):
         if isinstance(o, (datetime, date)):
             return o.isoformat()
         return o.__dict__
 
+
 class Citation:
 
-    def __init__(self, url, instantiate_empty=False):
+    def __init__(self, url, instantiate_empty=False, override=None):
         self.url = url
         self.baseurl = None
         self.file_url = None
         self.file_contents = None
         self.as_yaml = None
+        self.override = override
         if not instantiate_empty:
             self._get_baseurl()
             self._retrieve_file()
             self._parse_yaml()
+            self._override_suspect_keys()
 
     def _get_baseurl(self):
         if self.url[0:18] == "https://github.com":
             self.baseurl = "https://raw.githubusercontent.com"
         else:
             raise Exception("Only 'https://github.com' URLs are supported at the moment.")
+
+    def _override_suspect_keys(self):
+        if self.override is not None and type(self.override) is dict:
+            for key in self.override.keys():
+                self.as_yaml[key] = self.override[key]
+                self.file_contents = yaml.safe_dump(self.as_yaml, default_flow_style=False)
 
     def _retrieve_file(self):
 

--- a/fixtures/bibtex-5
+++ b/fixtures/bibtex-5
@@ -1,0 +1,11 @@
+@misc{YourReferenceHere,
+author = {
+            Jurriaan H. Spaaks and
+            Tom Klaver
+         },
+title  = {cff-converter-python},
+month  = {3},
+year   = {2018},
+doi    = {thebestdoi.23678237},
+url    = {https://github.com/citation-file-format/cff-converter-python}
+}

--- a/fixtures/codemeta-5
+++ b/fixtures/codemeta-5
@@ -1,0 +1,28 @@
+{
+    "@context": "http://schema.org",
+    "@type": "SoftwareSourceCode",
+    "codeRepository": "https://github.com/citation-file-format/cff-converter-python",
+    "datePublished": "2018-03-05",
+    "author": [{
+        "@type": "Person",
+        "givenName": "Jurriaan H.",
+        "familyName": "Spaaks",
+        "affiliation": {
+            "@type": "Organization",
+            "legalName": "Netherlands eScience Center"
+        }
+    }, {
+        "@type": "Person",
+        "givenName": "Tom",
+        "familyName": "Klaver",
+        "affiliation": {
+            "@type": "Organization",
+            "legalName": "Netherlands eScience Center"
+        }
+    }],
+    "keywords": ["citation", "bibliography", "cff", "CITATION.cff"],
+    "license": "http://www.apache.org/licenses/LICENSE-2.0",
+    "version": "1.0.0",
+    "identifier": "https://doi.org/thebestdoi.23678237",
+    "name": "cff-converter-python"
+}

--- a/fixtures/endnote-5
+++ b/fixtures/endnote-5
@@ -1,0 +1,40 @@
+%0
+%0 Generic
+%A Spaaks, Jurriaan H. & Klaver, Tom
+%D 2018
+%T cff-converter-python
+%E
+%B
+%C
+%I GitHub repository
+%V
+%6
+%N
+%P
+%&
+%Y
+%S
+%7
+%8 3
+%9
+%?
+%!
+%Z
+%@
+%(
+%)
+%*
+%L
+%M
+
+
+%2
+%3
+%4
+%#
+%$
+%F YourReferenceHere
+%K "citation", "bibliography", "cff", "CITATION.cff"
+%X
+%Z
+%U https://github.com/citation-file-format/cff-converter-python

--- a/fixtures/ris-5
+++ b/fixtures/ris-5
@@ -1,0 +1,15 @@
+TY  - COMP
+AU  - Spaaks, Jurriaan H.
+AU  - Klaver, Tom
+DO  - thebestdoi.23678237
+KW  - citation
+KW  - bibliography
+KW  - cff
+KW  - CITATION.cff
+M3  - software
+PB  - GitHub Inc.
+PP  - San Francisco, USA
+PY  - 2018/03/05
+T1  - cff-converter-python
+UR  - https://github.com/citation-file-format/cff-converter-python
+ER  -

--- a/livetest/citation_test.py
+++ b/livetest/citation_test.py
@@ -1,6 +1,6 @@
 import unittest
 import os
-import yaml
+import datetime
 from cff_converter_python import Citation
 
 
@@ -194,7 +194,10 @@ class CitationTestOverride(unittest.TestCase):
     def setUp(self):
         # with override
         url = "https://github.com/citation-file-format/cff-converter-python"
-        override = yaml.safe_load('doi: "thebestdoi.23678237"\ndate-released: 2018-03-05')
+        override = {
+            "doi": "thebestdoi.23678237",
+            "date-released": datetime.datetime.strptime("2018-03-05", "%Y-%m-%d").date()
+        }
         self.citation = Citation(url, override=override)
 
     def test_printing_as_bibtex(self):

--- a/livetest/citation_test.py
+++ b/livetest/citation_test.py
@@ -1,5 +1,6 @@
 import unittest
 import os
+import yaml
 from cff_converter_python import Citation
 
 
@@ -186,6 +187,43 @@ class CitationTestInvalidInput(unittest.TestCase):
             self.citation = Citation(url)
 
         self.assertTrue('Error requesting file: ' in str(context.exception))
+
+
+class CitationTestOverride(unittest.TestCase):
+
+    def setUp(self):
+        # with override
+        url = "https://github.com/citation-file-format/cff-converter-python"
+        override = yaml.safe_load('doi: "thebestdoi.23678237"\ndate-released: 2018-03-05')
+        self.citation = Citation(url, override=override)
+
+    def test_printing_as_bibtex(self):
+        fixture = os.path.join("fixtures", "bibtex-5")
+        with open(fixture) as f:
+            expected_bibtex = f.read()
+        actual_bibtex = self.citation.as_bibtex()
+        self.assertEqual(expected_bibtex, actual_bibtex)
+
+    def test_printing_as_codemeta(self):
+        fixture = os.path.join("fixtures", "codemeta-5")
+        with open(fixture) as f:
+            expected_codemeta = f.read()
+        actual_codemeta = self.citation.as_codemeta()
+        self.assertEqual(expected_codemeta, actual_codemeta)
+
+    def test_printing_as_enw(self):
+        fixture = os.path.join("fixtures", "endnote-5")
+        with open(fixture) as f:
+            expected_endnote = f.read()
+        actual_endnote = self.citation.as_enw()
+        self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_ris(self):
+        fixture = os.path.join("fixtures", "ris-5")
+        with open(fixture) as f:
+            expected_ris = f.read()
+        actual_ris = self.citation.as_ris()
+        self.assertEqual(expected_ris, actual_ris)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
``doi`` and ``date-released`` from the citationcff are almost always out of date, this PR adds functionality to override those keys with custom values, for example those returned by a DOI supplier like Zenodo.

see also: https://github.com/research-software-directory/landing-page/issues/77