### PR TITLE
set jsonld @context to http://schema.org

### DIFF
--- a/cffconvert/citation.py
+++ b/cffconvert/citation.py
@@ -242,10 +242,7 @@ class Citation:
             return authors
 
         d = dict()
-        d["@context"] = [
-            "https://doi.org/10.5063/schema/codemeta-2.0",
-            "http://schema.org"
-        ]
+        d["@context"] = "http://schema.org"
         d["@type"] = "SoftwareSourceCode"
         if self._key_should_be_included("repository-code"):
             d["codeRepository"] = self.yaml["repository-code"]

--- a/fixtures/1/codemeta.json
+++ b/fixtures/1/codemeta.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
-    ],
+    "@context": "http://schema.org",
     "@type": "SoftwareSourceCode",
     "author": [
         {

--- a/fixtures/2/codemeta.json
+++ b/fixtures/2/codemeta.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
-    ],
+    "@context": "http://schema.org",
     "@type": "SoftwareSourceCode",
     "author": [
         {

--- a/fixtures/3/codemeta.json
+++ b/fixtures/3/codemeta.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
-    ],
+    "@context": "http://schema.org",
     "@type": "SoftwareSourceCode",
     "author": [
         {

--- a/fixtures/5/codemeta.json
+++ b/fixtures/5/codemeta.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
-    ],
+    "@context": "http://schema.org",
     "@type": "SoftwareSourceCode",
     "author": [
         {

--- a/fixtures/6/codemeta-no-date.json
+++ b/fixtures/6/codemeta-no-date.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
-    ],
+    "@context": "http://schema.org",
     "@type": "SoftwareSourceCode",
     "author": [
         {

--- a/fixtures/6/codemeta-no-doi.json
+++ b/fixtures/6/codemeta-no-doi.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
-    ],
+    "@context": "http://schema.org",
     "@type": "SoftwareSourceCode",
     "author": [
         {

--- a/fixtures/6/codemeta-no-suspect-keys.json
+++ b/fixtures/6/codemeta-no-suspect-keys.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
-    ],
+    "@context": "http://schema.org",
     "@type": "SoftwareSourceCode",
     "author": [
         {

--- a/fixtures/6/codemeta-no-version.json
+++ b/fixtures/6/codemeta-no-version.json
@@ -1,8 +1,5 @@
 {
-    "@context": [
-        "https://doi.org/10.5063/schema/codemeta-2.0",
-        "http://schema.org"
-    ],
+    "@context": "http://schema.org",
     "@type": "SoftwareSourceCode",
     "author": [
         {


### PR DESCRIPTION
Current version breaks (at least for google interpreter, see e.g. https://search.google.com/structured-data/testing-tool/u/0/#url=https%3A%2F%2Fwww.research-software.nl%2Fsoftware%2Fxenon ). 

https://www.w3.org/TR/json-ld/#the-context doesn't mention an array as @context.
Examples @ https://github.com/codemeta/codemeta/tree/master/examples are not so clear to me either.

So I'm confused, at least these modifications seem to be okay according to the Google interpreter - but I guess CodeMetas schema additions are not picked up in this way.