### PR TITLE
removed PyYAML dependency in favor of ruamel.yaml

### DIFF
--- a/cffconvert/citation.py
+++ b/cffconvert/citation.py
@@ -1,7 +1,7 @@
 import sys
 import os
 import requests
-import yaml
+import ruamel.yaml as yaml
 import re
 import json
 from datetime import datetime, date

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 click==6.7
-PyYAML==3.12
 requests==2.20.0
 pykwalifire==2.0.1
+
+# use highest version of ruamel.yaml that is consistent with the 
+# dependency of pykwalifire:
+ruamel.yaml==0.11.15

--- a/test/consistency_test.py
+++ b/test/consistency_test.py
@@ -1,7 +1,7 @@
 import unittest
 import os
 import json
-import yaml
+import ruamel.yaml as yaml
 from cffconvert.version import __version__ as expected_version
 
 


### PR DESCRIPTION
because one of cffconvert's dependencies (``pykwalifire``) uses ``ruamel.yaml>=0.11.0,<0.12.0``:

https://github.com/sdruskat/pykwalifire/blob/d72869cab73441cb074100bd31a6c0795e16c41e/setup.py#L28

related: https://github.com/citation-file-format/cff-converter-python/issues/9
