### PR TITLE
Schema.org

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -20,6 +20,7 @@
             "orcid": "0000-0003-4925-7248"
         }
     ],
+    "description": "Command line program to convert from Citation File Format to various other formats such as BibTeX, EndNote, RIS, schema.org, and .zenodo.json.",
     "keywords": [
         "citation",
         "bibliography",

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,5 +1,6 @@
 # YAML 1.2
 ---
+abstract: "Command line program to convert from Citation File Format to various other formats such as BibTeX, EndNote, RIS, schema.org, and .zenodo.json."
 authors:
   -
     affiliation: "Netherlands eScience Center"

--- a/README.rst
+++ b/README.rst
@@ -18,10 +18,11 @@ url and convert it to various formats, such as:
 
 1. BibTeX
 2. EndNote
-3. RIS
-4. codemeta
-5. plain JSON
-6. Zenodo JSON
+3. codemeta
+4. plain JSON
+5. schema.org
+6. RIS
+7. Zenodo JSON
 
 Supported types of GitHub URL:
 
@@ -127,7 +128,7 @@ Shows:
     Options:
       -if, --infile TEXT          Path to the CITATION.cff input file.
       -of, --outfile TEXT         Path to the output file.
-      -f, --outputformat TEXT     Output format: bibtex|cff|codemeta|endnote|ris|zenodo
+      -f, --outputformat TEXT     Output format: bibtex|cff|codemeta|endnote|schema.org|ris|zenodo
       -u, --url TEXT              URL of the repo containing the CITATION.cff (currently only github.com is supported; may
                                   include branch name, commit sha, tag name). For example: 'https://github.com/citation-
                                   file-format/cff-converter-python' or 'https://github.com/citation-file-format/cff-

--- a/cffconvert/cli.py
+++ b/cffconvert/cli.py
@@ -59,7 +59,7 @@ def cli(infile, outfile, outputformat, url, validate, ignore_suspect_keys, verbo
     citation = Citation(url=url, cffstr=cffstr, ignore_suspect_keys=ignore_suspect_keys, override=override,
                         remove=remove, suspect_keys=suspect_keys, validate=validate)
 
-    acceptable_output_formats = ["bibtex", "cff", "codemeta", "endnote", "ris", "zenodo"]
+    acceptable_output_formats = ["bibtex", "cff", "codemeta", "endnote", "ris", "schema.org", "zenodo"]
     if validate:
         pass
     elif outputformat not in acceptable_output_formats:
@@ -69,16 +69,18 @@ def cli(infile, outfile, outputformat, url, validate, ignore_suspect_keys, verbo
         return
     elif outputformat == "bibtex":
         outstr = citation.as_bibtex()
+    elif outputformat == "cff":
+        outstr = citation.cffstr
     elif outputformat == "codemeta":
         outstr = citation.as_codemeta()
     elif outputformat == "endnote":
         outstr = citation.as_enw()
     elif outputformat == "ris":
         outstr = citation.as_ris()
+    elif outputformat == "schema.org":
+        outstr = citation.as_schema_dot_org()
     elif outputformat == "zenodo":
         outstr = citation.as_zenodojson()
-    elif outputformat == "cff":
-        outstr = citation.cffstr
 
     if outfile is None:
         print(outstr)

--- a/cffconvert/gcloud.py
+++ b/cffconvert/gcloud.py
@@ -50,8 +50,8 @@ style="font-family:monospace"><a
 href="https://pypi.org/project/cffconvert/">cffconvert</a></span>.
 
 With this page, you can read a CFF formatted CITATION file from a supplied
-string or a GitHub url, and convert it to BibTeX, EndNote, RIS, Codemeta,
-.zenodo.json, or plain JSON. The way to do that is by supplying various
+string or a GitHub url, and convert it to BibTeX, EndNote, Codemeta, RIS, schema.org,
+plain JSON, Zenodo JSON. The way to do that is by supplying various
 combinations of arguments as query parameters in the URL (see examples 
 below).
 
@@ -73,6 +73,7 @@ convert to various other formats, as follows.
 <ul>
 <li><a href="?url=https://github.com/citation-file-format/cff-converter-python&outputformat=codemeta"><span style="font-family:monospace">?url=https://github.com/citation-file-format/cff-converter-python&outputformat=codemeta</span></a></li>
 <li><a href="?url=https://github.com/citation-file-format/cff-converter-python&outputformat=endnote"><span style="font-family:monospace">?url=https://github.com/citation-file-format/cff-converter-python&outputformat=endnote</span></a></li>
+<li><a href="?url=https://github.com/citation-file-format/cff-converter-python&outputformat=schema.org"><span style="font-family:monospace">?url=https://github.com/citation-file-format/cff-converter-python&outputformat=schema.org</span></a></li>
 <li><a href="?url=https://github.com/citation-file-format/cff-converter-python&outputformat=ris"><span style="font-family:monospace">?url=https://github.com/citation-file-format/cff-converter-python&outputformat=ris</span></a></li>
 <li><a href="?url=https://github.com/citation-file-format/cff-converter-python&outputformat=zenodo"><span style="font-family:monospace">?url=https://github.com/citation-file-format/cff-converter-python&outputformat=zenodo</span></a></li>
 </ul>
@@ -202,7 +203,7 @@ def cffconvert(request):
             outstr += "\n\nError: " + str(e)
         return Response(outstr, mimetype='text/plain')
 
-    acceptable_output_formats = ["bibtex", "cff", "codemeta", "endnote", "ris", "zenodo"]
+    acceptable_output_formats = ["bibtex", "cff", "codemeta", "endnote", "schema.org", "ris", "zenodo"]
     if validate:
         pass
     elif outputformat not in acceptable_output_formats:
@@ -213,15 +214,17 @@ def cffconvert(request):
         return
     elif outputformat == "bibtex":
         outstr += citation.as_bibtex()
+    elif outputformat == "cff":
+        outstr += citation.cffstr
     elif outputformat == "codemeta":
         outstr += citation.as_codemeta()
     elif outputformat == "endnote":
         outstr += citation.as_enw()
     elif outputformat == "ris":
         outstr += citation.as_ris()
+    elif outputformat == "schema.org":
+        outstr += citation.as_schema_dot_org()
     elif outputformat == "zenodo":
         outstr += citation.as_zenodojson()
-    elif outputformat == "cff":
-        outstr += citation.cffstr
 
     return Response(outstr, mimetype='text/plain')

--- a/fixtures/1/schema-dot-org.json
+++ b/fixtures/1/schema-dot-org.json
@@ -1,0 +1,36 @@
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "author": [
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Spaaks",
+            "givenName": "Jurriaan H."
+        },
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Klaver",
+            "givenName": "Tom"
+        }
+    ],
+    "codeRepository": "https://github.com/citation-file-format/cff-converter-python",
+    "datePublished": "2018-01-16",
+    "identifier": "https://doi.org/10.5281/zenodo.1162057",
+    "keywords": [
+        "citation",
+        "bibliography",
+        "cff",
+        "CITATION.cff"
+    ],
+    "license": "http://www.apache.org/licenses/LICENSE-2.0",
+    "name": "cff-converter-python",
+    "version": "1.0.0"
+}

--- a/fixtures/2/schema-dot-org.json
+++ b/fixtures/2/schema-dot-org.json
@@ -1,0 +1,13 @@
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "author": [
+        {
+            "@type": "Person",
+            "familyName": "Fernández de Córdoba Jr.",
+            "givenName": "Gonzalo"
+        }
+    ],
+    "name": "example title",
+    "version": "1.0.0"
+}

--- a/fixtures/3/schema-dot-org.json
+++ b/fixtures/3/schema-dot-org.json
@@ -1,0 +1,53 @@
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "author": [
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "van Kuppevelt",
+            "givenName": "Dafne"
+        },
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Meijer",
+            "givenName": "Christiaan"
+        },
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "van Hees",
+            "givenName": "Vincent"
+        },
+        {
+            "@id": "https://orcid.org/0000-0003-0087-6021",
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Kuzak",
+            "givenName": "Mateusz"
+        }
+    ],
+    "codeRepository": "https://github.com/NLeSC/mcfly",
+    "keywords": [
+        "machine learning",
+        "deep learning",
+        "time series",
+        "automatic classification"
+    ],
+    "license": "http://www.apache.org/licenses/LICENSE-2.0",
+    "name": "mcfly",
+    "version": "1.0.1"
+}

--- a/fixtures/5/schema-dot-org.json
+++ b/fixtures/5/schema-dot-org.json
@@ -1,0 +1,36 @@
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "author": [
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Spaaks",
+            "givenName": "Jurriaan H."
+        },
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Klaver",
+            "givenName": "Tom"
+        }
+    ],
+    "codeRepository": "https://github.com/citation-file-format/cff-converter-python",
+    "datePublished": "2018-03-05",
+    "identifier": "https://doi.org/thebestdoi.23678237",
+    "keywords": [
+        "citation",
+        "bibliography",
+        "cff",
+        "CITATION.cff"
+    ],
+    "license": "http://www.apache.org/licenses/LICENSE-2.0",
+    "name": "cff-converter-python",
+    "version": "1.0.0"
+}

--- a/fixtures/6/schema-dot-org-no-date.json
+++ b/fixtures/6/schema-dot-org-no-date.json
@@ -1,0 +1,36 @@
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "author": [
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Attema",
+            "givenName": "Jisk"
+        },
+        {
+            "@id": "https://orcid.org/0000-0002-0989-929X",
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Diblen",
+            "givenName": "Faruk"
+        }
+    ],
+    "codeRepository": "https://github.com/NLeSC/spot",
+    "identifier": "https://doi.org/10.5281/zenodo.1003346",
+    "keywords": [
+        "visualization",
+        "big data",
+        "visual data analytics",
+        "multi-dimensional data"
+    ],
+    "license": "http://www.apache.org/licenses/LICENSE-2.0",
+    "name": "spot",
+    "version": "0.1.0"
+}

--- a/fixtures/6/schema-dot-org-no-doi.json
+++ b/fixtures/6/schema-dot-org-no-doi.json
@@ -1,0 +1,36 @@
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "author": [
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Attema",
+            "givenName": "Jisk"
+        },
+        {
+            "@id": "https://orcid.org/0000-0002-0989-929X",
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Diblen",
+            "givenName": "Faruk"
+        }
+    ],
+    "codeRepository": "https://github.com/NLeSC/spot",
+    "datePublished": "2017-10-07",
+    "keywords": [
+        "visualization",
+        "big data",
+        "visual data analytics",
+        "multi-dimensional data"
+    ],
+    "license": "http://www.apache.org/licenses/LICENSE-2.0",
+    "name": "spot",
+    "version": "0.1.0"
+}

--- a/fixtures/6/schema-dot-org-no-suspect-keys.json
+++ b/fixtures/6/schema-dot-org-no-suspect-keys.json
@@ -1,0 +1,34 @@
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "author": [
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Attema",
+            "givenName": "Jisk"
+        },
+        {
+            "@id": "https://orcid.org/0000-0002-0989-929X",
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Diblen",
+            "givenName": "Faruk"
+        }
+    ],
+    "codeRepository": "https://github.com/NLeSC/spot",
+    "keywords": [
+        "visualization",
+        "big data",
+        "visual data analytics",
+        "multi-dimensional data"
+    ],
+    "license": "http://www.apache.org/licenses/LICENSE-2.0",
+    "name": "spot"
+}

--- a/fixtures/6/schema-dot-org-no-version.json
+++ b/fixtures/6/schema-dot-org-no-version.json
@@ -1,0 +1,36 @@
+{
+    "@context": "https://schema.org",
+    "@type": "SoftwareSourceCode",
+    "author": [
+        {
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Attema",
+            "givenName": "Jisk"
+        },
+        {
+            "@id": "https://orcid.org/0000-0002-0989-929X",
+            "@type": "Person",
+            "affiliation": {
+                "@type": "Organization",
+                "legalName": "Netherlands eScience Center"
+            },
+            "familyName": "Diblen",
+            "givenName": "Faruk"
+        }
+    ],
+    "codeRepository": "https://github.com/NLeSC/spot",
+    "datePublished": "2017-10-07",
+    "identifier": "https://doi.org/10.5281/zenodo.1003346",
+    "keywords": [
+        "visualization",
+        "big data",
+        "visual data analytics",
+        "multi-dimensional data"
+    ],
+    "license": "http://www.apache.org/licenses/LICENSE-2.0",
+    "name": "spot"
+}

--- a/test/citation_test.py
+++ b/test/citation_test.py
@@ -40,6 +40,13 @@ class CitationTest1(unittest.TestCase):
         actual_ris = self.citation.as_ris()
         self.assertEqual(expected_ris, actual_ris)
 
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "1", "schema-dot-org.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
+
     def test_printing_as_zenodojson(self):
         fixture = os.path.join("fixtures", "1", "zenodo.json")
         with open(fixture, "r") as f:
@@ -84,6 +91,13 @@ class CitationTest2(unittest.TestCase):
         actual_ris = self.citation.as_ris()
         self.assertEqual(expected_ris, actual_ris)
 
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "2", "schema-dot-org.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
+
     def test_printing_as_zenodojson(self):
         fixture = os.path.join("fixtures", "2", "zenodo.json")
         with open(fixture, "r") as f:
@@ -120,6 +134,13 @@ class CitationTest3(unittest.TestCase):
             expected_endnote = f.read()
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "3", "schema-dot-org.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
 
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "3", "ris.txt")
@@ -187,6 +208,13 @@ class CitationTestOverride(unittest.TestCase):
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
 
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "5", "schema-dot-org.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
+
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "5", "ris.txt")
         with open(fixture, "r") as f:
@@ -228,6 +256,13 @@ class CitationTestRemoveSuspectKeyDate(unittest.TestCase):
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
 
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "6", "schema-dot-org-no-date.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
+
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "6", "ris-no-date.txt")
         with open(fixture, "r") as f:
@@ -266,6 +301,13 @@ class CitationTestIgnoreSuspectKeyDate(unittest.TestCase):
             expected_endnote = f.read()
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "6", "schema-dot-org-no-date.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
 
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "6", "ris-no-date.txt")
@@ -308,6 +350,13 @@ class CitationTestRemoveSuspectKeyDoi(unittest.TestCase):
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
 
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "6", "schema-dot-org-no-doi.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
+
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "6", "ris-no-doi.txt")
         with open(fixture, "r") as f:
@@ -346,6 +395,13 @@ class CitationTestIgnoreSuspectKeyDoi(unittest.TestCase):
             expected_endnote = f.read()
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "6", "schema-dot-org-no-doi.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
 
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "6", "ris-no-doi.txt")
@@ -388,6 +444,13 @@ class CitationTestRemoveSuspectKeyVersion(unittest.TestCase):
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
 
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "6", "schema-dot-org-no-version.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
+
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "6", "ris-no-version.txt")
         with open(fixture, "r") as f:
@@ -427,6 +490,13 @@ class CitationTestIgnoreSuspectKeyVersion(unittest.TestCase):
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
 
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "6", "schema-dot-org-no-version.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
+
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "6", "ris-no-version.txt")
         with open(fixture, "r") as f:
@@ -464,6 +534,13 @@ class CitationTestIgnoreAllSuspectKeys(unittest.TestCase):
             expected_endnote = f.read()
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "6", "schema-dot-org-no-suspect-keys.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
 
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "6", "ris-no-suspect-keys.txt")
@@ -506,6 +583,13 @@ class CitationTestRemoveNonExistentKey(unittest.TestCase):
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
 
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "1", "schema-dot-org.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
+
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "1", "ris.txt")
         with open(fixture, "r") as f:
@@ -544,6 +628,13 @@ class CitationTestIgnoreNonExistentKey(unittest.TestCase):
             expected_endnote = f.read()
         actual_endnote = self.citation.as_enw()
         self.assertEqual(expected_endnote, actual_endnote)
+
+    def test_printing_as_schema_dot_org(self):
+        fixture = os.path.join("fixtures", "1", "schema-dot-org.json")
+        with open(fixture, "r") as f:
+            expected_schema_dot_org = f.read()
+        actual_schema_dot_org = self.citation.as_schema_dot_org()
+        self.assertEqual(expected_schema_dot_org, actual_schema_dot_org)
 
     def test_printing_as_ris(self):
         fixture = os.path.join("fixtures", "1", "ris.txt")

--- a/test/cli_test.py
+++ b/test/cli_test.py
@@ -138,6 +138,24 @@ class CliTestsFromLocalCffFile(unittest.TestCase):
         self.assertTrue(result.exit_code == 0)
         self.assertEqual(expected_output, actual_output)
 
+    def test_printing_as_schema_dot_org_from_local_cff_file(self):
+        fixture_schema_dot_org = os.path.join("fixtures", "1", "schema-dot-org.json")
+        with open(fixture_schema_dot_org, "r") as f:
+            expected_output = f.read() + "\n"
+
+        fixture_cff = os.path.join("fixtures", "1", "CITATION.cff")
+        with open(fixture_cff, "r") as f:
+            cff_contents = f.read()
+
+        with self.runner.isolated_filesystem():
+            with open("CITATION.cff", "w") as f:
+                f.write(cff_contents)
+            result = self.runner.invoke(cffconvert_cli, ["-f", "schema.org"])
+            actual_output = result.output
+
+        self.assertTrue(result.exit_code == 0)
+        self.assertEqual(expected_output, actual_output)
+
     def test_printing_as_zenodojson_from_local_cff_file(self):
         fixture_zenodo = os.path.join("fixtures", "1", "zenodo.json")
         with open(fixture_zenodo, "r") as f:


### PR DESCRIPTION
It seems that Google was having some issues with interpreting the codemeta we generate for the Research Software Directory
- https://github.com/research-software-directory/research-software-directory/blob/b2c08d59cf143f843eb5e4facd136818a9346a2a/harvesting/releases.py#L176
- https://github.com/research-software-directory/research-software-directory/blob/b2c08d59cf143f843eb5e4facd136818a9346a2a/harvesting/releases.py#L223

, therefore I added an export that just uses schema.org for its context, instead of both codemeta and schema.org.

