### PR TITLE
Fix #106: Use fixed schema for CFF 1.0.3

### DIFF
--- a/cffconvert/citation.py
+++ b/cffconvert/citation.py
@@ -132,6 +132,11 @@ class Citation:
 
         if semver is None:
             raise ValueError("Unable to identify the schema version. Does the CFF include the 'cff-version' key?")
+        # Hard-coded fix for https://github.com/citation-file-format/cff-converter-python/issues/106.
+        # 1.0.3-1 schema will be the last one using pykwalifire/schema.yaml, therefore
+        # this hard-coded fix is acceptable.
+        elif semver == '1.0.3':
+            semver = '1.0.3-1'
         schema_url = "https://raw.githubusercontent.com/citation-file-format/" +\
                      "schema/{0}/CFF-Core/schema.yaml".format(semver)
         r = requests.get(schema_url)


### PR DESCRIPTION
This fix hard-codes the use of schema version 1.0.3-1 for CFF files with a value of `cff-version: 1.0.3`.
This hard-coding seems reasonable as 1.0.3-1 is the last version that will use the `schema.yaml` + *pykwalifire* validation method.

This PR fixes #106.