### PR TITLE
Fix #153: Add utf8 encoding to all calls to open

### DIFF
--- a/cffconvert/citation.py
+++ b/cffconvert/citation.py
@@ -148,9 +148,9 @@ class Citation:
 
             datafile = os.path.join(tmpdir, "data.yaml")
             schemafile = os.path.join(tmpdir, "schema.yaml")
-            with open(datafile, "w") as f:
+            with open(datafile, "w", encoding="utf8") as f:
                 f.write(self.cffstr)
-            with open(schemafile, "w") as f:
+            with open(schemafile, "w", encoding="utf8") as f:
                 f.write(self.schema)
 
             c = Core(source_file=datafile, schema_files=[schemafile])

--- a/cffconvert/cli.py
+++ b/cffconvert/cli.py
@@ -51,7 +51,7 @@ def cli(infile, outfile, outputformat, url, validate, ignore_suspect_keys, verbo
     elif infile == '-':
         cffstr = sys.stdin.read()
     else:
-        with open(infile, "r") as f:
+        with open(infile, "r", encoding="utf8") as f:
             cffstr = f.read()
 
     # TODO currently there is no way to provide values for these 3 arguments from the command line
@@ -91,7 +91,7 @@ def cli(infile, outfile, outputformat, url, validate, ignore_suspect_keys, verbo
     if outfile is None:
         print(outstr, end='')
     else:
-        with open(outfile, "w") as f:
+        with open(outfile, "w", encoding="utf8") as f:
             f.write(outstr)
 
 if __name__ == "__main__":

--- a/livetest/02/CitationTestUrlHasOrgRepoTreeSha02.py
+++ b/livetest/02/CitationTestUrlHasOrgRepoTreeSha02.py
@@ -11,7 +11,7 @@ class CitationTestUrlHasOrgRepoTreeSha(unittest.TestCase):
               "b7505591cf421ab33156ec0bffb0af43fd7d2cd1"
         citation = Citation(url=url)
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture) as f:
+        with open(fixture, encoding="utf8") as f:
             expected_cffstr = f.read()
         actual_cffstr = citation.cffstr
         self.assertEqual(expected_cffstr, actual_cffstr)

--- a/livetest/03/CitationTestUrlHasOrgRepoTreeTag03.py
+++ b/livetest/03/CitationTestUrlHasOrgRepoTreeTag03.py
@@ -10,7 +10,7 @@ class CitationTestUrlHasOrgRepoTreeTag(unittest.TestCase):
         url = "https://github.com/citation-file-format/cff-converter-python/tree/0.0.1"
         citation = Citation(url=url)
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture) as f:
+        with open(fixture, encoding="utf8") as f:
             expected_cffstr = f.read()
         actual_cffstr = citation.cffstr
         self.assertEqual(expected_cffstr, actual_cffstr)

--- a/setup.py
+++ b/setup.py
@@ -6,19 +6,19 @@ from distutils.util import convert_path
 
 
 def get_install_dependencies():
-    with open("requirements.txt", "r") as f:
+    with open("requirements.txt", "r", encoding="utf8") as f:
         lines = f.readlines()
     return [line.rstrip('\n') for line in lines]
 
 
 def get_test_dependencies():
-    with open("requirements-dev.txt", "r") as f:
+    with open("requirements-dev.txt", "r", encoding="utf8") as f:
         lines = f.readlines()
     return [line.rstrip('\n') for line in lines]
 
 
 def get_readme():
-    with open("README.rst", "r") as f:
+    with open("README.rst", "r", encoding="utf8") as f:
         return f.read()
 
 
@@ -27,7 +27,7 @@ def get_version():
     # -my-package#answer-24517154
     version_namespace = {}
     version_path = convert_path('cffconvert/version.py')
-    with open(version_path) as version_file:
+    with open(version_path, encoding="utf8") as version_file:
         exec(version_file.read(), version_namespace)
     return version_namespace["__version__"]
 

--- a/test/1.0.3/01/ApalikeObjectTest01.py
+++ b/test/1.0.3/01/ApalikeObjectTest01.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.0.3/01/BibtexObjectTest01.py
+++ b/test/1.0.3/01/BibtexObjectTest01.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.0.3/01/CliTest01.py
+++ b/test/1.0.3/01/CliTest01.py
@@ -10,7 +10,7 @@ class CliTests(unittest.TestCase):
     @staticmethod
     def read_sibling_file(filename):
         f = os.path.join(os.path.dirname(__file__), filename)
-        with open(f, "r") as f:
+        with open(f, "r", encoding="utf8") as f:
             return f.read()
 
     def test_local_cff_file_does_not_exist(self):
@@ -39,7 +39,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("bibtex.bib")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "bibtex"])
         self.assertEqual(result.exit_code, 0)
@@ -51,7 +51,7 @@ class CliTests(unittest.TestCase):
         expected = yaml.safe_load(cffstr)
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "cff"])
         self.assertEqual(result.exit_code, 0)
@@ -63,7 +63,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("codemeta.json")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "codemeta"])
         self.assertEqual(result.exit_code, 0)
@@ -75,7 +75,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("endnote.enw")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "endnote"])
         self.assertEqual(result.exit_code, 0)
@@ -87,7 +87,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("ris.txt")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "ris"])
         self.assertEqual(result.exit_code, 0)
@@ -99,7 +99,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("schemaorg.json")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "schema.org"])
         self.assertEqual(result.exit_code, 0)
@@ -132,7 +132,7 @@ class CliTests(unittest.TestCase):
         cffstr = CliTests.read_sibling_file("CITATION.cff")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "unsupported_97491"])
         self.assertEqual(result.exit_code, -1)
@@ -152,11 +152,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("bibtex.bib")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "bibtex",
                                                          "--outfile", "bibtex.bib"])
-            with open("bibtex.bib", "r") as f:
+            with open("bibtex.bib", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)
@@ -166,11 +166,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("codemeta.json")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "codemeta",
                                                          "--outfile", "codemeta.json"])
-            with open("codemeta.json", "r") as f:
+            with open("codemeta.json", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)
@@ -180,11 +180,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("endnote.enw")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "endnote",
                                                          "--outfile", "endnote.enw"])
-            with open("endnote.enw", "r") as f:
+            with open("endnote.enw", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)
@@ -194,11 +194,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("ris.txt")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "ris",
                                                          "--outfile", "ris.txt"])
-            with open("ris.txt", "r") as f:
+            with open("ris.txt", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)
@@ -208,11 +208,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("schemaorg.json")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "schema.org",
                                                          "--outfile", "schemaorg.json"])
-            with open("schemaorg.json", "r") as f:
+            with open("schemaorg.json", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)

--- a/test/1.0.3/01/CodemetaObjectTest01.py
+++ b/test/1.0.3/01/CodemetaObjectTest01.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.0.3/01/EndnoteObjectTest01.py
+++ b/test/1.0.3/01/EndnoteObjectTest01.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.0.3/01/RisObjectTest01.py
+++ b/test/1.0.3/01/RisObjectTest01.py
@@ -9,7 +9,7 @@ class RisObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ro = RisObject(cff_object, initialize_empty=True)
@@ -41,7 +41,7 @@ class RisObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_ris = self.ro.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "ris.txt")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_ris = f.read()
         self.assertEqual(actual_ris, expected_ris)
 

--- a/test/1.0.3/01/SchemaorgObjectTest01.py
+++ b/test/1.0.3/01/SchemaorgObjectTest01.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.0.3/01/ZenodoObjectTest01.py
+++ b/test/1.0.3/01/ZenodoObjectTest01.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -47,7 +47,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.0.3/02/ApalikeObjectTest02.py
+++ b/test/1.0.3/02/ApalikeObjectTest02.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.0.3/02/BibtexObjectTest02.py
+++ b/test/1.0.3/02/BibtexObjectTest02.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.0.3/02/CodemetaObjectTest02.py
+++ b/test/1.0.3/02/CodemetaObjectTest02.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -62,7 +62,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.0.3/02/EndnoteObjectTest02.py
+++ b/test/1.0.3/02/EndnoteObjectTest02.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.0.3/02/SchemaorgObjectTest02.py
+++ b/test/1.0.3/02/SchemaorgObjectTest02.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -62,7 +62,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.0.3/02/ZenodoObjectTest02.py
+++ b/test/1.0.3/02/ZenodoObjectTest02.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -42,7 +42,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.0.3/03/ApalikeObjectTest03.py
+++ b/test/1.0.3/03/ApalikeObjectTest03.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.0.3/03/BibtexObjectTest03.py
+++ b/test/1.0.3/03/BibtexObjectTest03.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.0.3/03/CodemetaObjectTest03.py
+++ b/test/1.0.3/03/CodemetaObjectTest03.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -76,7 +76,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.0.3/03/EndnoteObjectTest03.py
+++ b/test/1.0.3/03/EndnoteObjectTest03.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -38,7 +38,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.0.3/03/SchemaorgObjectTest03.py
+++ b/test/1.0.3/03/SchemaorgObjectTest03.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -76,7 +76,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.0.3/03/ZenodoObjectTest03.py
+++ b/test/1.0.3/03/ZenodoObjectTest03.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -48,7 +48,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.0.3/04/ApalikeObjectTest04.py
+++ b/test/1.0.3/04/ApalikeObjectTest04.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.0.3/04/BibtexObjectTest04.py
+++ b/test/1.0.3/04/BibtexObjectTest04.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -34,7 +34,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.0.3/04/CodemetaObjectTest04.py
+++ b/test/1.0.3/04/CodemetaObjectTest04.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -92,7 +92,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.0.3/04/EndnoteObjectTest04.py
+++ b/test/1.0.3/04/EndnoteObjectTest04.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -38,7 +38,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.0.3/04/SchemaorgObjectTest04.py
+++ b/test/1.0.3/04/SchemaorgObjectTest04.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -92,7 +92,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.0.3/04/ZenodoObjectTest04.py
+++ b/test/1.0.3/04/ZenodoObjectTest04.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -56,7 +56,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.0.3/05/ApalikeObjectTest05.py
+++ b/test/1.0.3/05/ApalikeObjectTest05.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.0.3/05/BibtexObjectTest05.py
+++ b/test/1.0.3/05/BibtexObjectTest05.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.0.3/05/CodemetaObjectTest05.py
+++ b/test/1.0.3/05/CodemetaObjectTest05.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -83,7 +83,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.0.3/05/EndnoteObjectTest05.py
+++ b/test/1.0.3/05/EndnoteObjectTest05.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.0.3/05/SchemaorgObjectTest05.py
+++ b/test/1.0.3/05/SchemaorgObjectTest05.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -83,7 +83,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.0.3/05/ZenodoObjectTest05.py
+++ b/test/1.0.3/05/ZenodoObjectTest05.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -51,7 +51,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.1.0/01/ApalikeObjectTest01.py
+++ b/test/1.1.0/01/ApalikeObjectTest01.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.1.0/01/BibtexObjectTest01.py
+++ b/test/1.1.0/01/BibtexObjectTest01.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.1.0/01/CliTest01.py
+++ b/test/1.1.0/01/CliTest01.py
@@ -10,7 +10,7 @@ class CliTests(unittest.TestCase):
     @staticmethod
     def read_sibling_file(filename):
         f = os.path.join(os.path.dirname(__file__), filename)
-        with open(f, "r") as f:
+        with open(f, "r", encoding="utf8") as f:
             return f.read()
 
     def test_local_cff_file_does_not_exist(self):
@@ -39,7 +39,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("bibtex.bib")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "bibtex"])
         self.assertEqual(result.exit_code, 0)
@@ -51,7 +51,7 @@ class CliTests(unittest.TestCase):
         expected = yaml.safe_load(cffstr)
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "cff"])
         self.assertEqual(result.exit_code, 0)
@@ -63,7 +63,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("codemeta.json")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "codemeta"])
         self.assertEqual(result.exit_code, 0)
@@ -75,7 +75,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("endnote.enw")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "endnote"])
         self.assertEqual(result.exit_code, 0)
@@ -87,7 +87,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("ris.txt")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "ris"])
         self.assertEqual(result.exit_code, 0)
@@ -99,7 +99,7 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("schemaorg.json")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "schema.org"])
         self.assertEqual(result.exit_code, 0)
@@ -132,7 +132,7 @@ class CliTests(unittest.TestCase):
         cffstr = CliTests.read_sibling_file("CITATION.cff")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "unsupported_97491"])
         self.assertEqual(result.exit_code, -1)
@@ -152,11 +152,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("bibtex.bib")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "bibtex",
                                                          "--outfile", "bibtex.bib"])
-            with open("bibtex.bib", "r") as f:
+            with open("bibtex.bib", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)
@@ -166,11 +166,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("codemeta.json")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "codemeta",
                                                          "--outfile", "codemeta.json"])
-            with open("codemeta.json", "r") as f:
+            with open("codemeta.json", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)
@@ -180,11 +180,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("endnote.enw")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "endnote",
                                                          "--outfile", "endnote.enw"])
-            with open("endnote.enw", "r") as f:
+            with open("endnote.enw", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)
@@ -194,11 +194,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("ris.txt")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "ris",
                                                          "--outfile", "ris.txt"])
-            with open("ris.txt", "r") as f:
+            with open("ris.txt", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)
@@ -208,11 +208,11 @@ class CliTests(unittest.TestCase):
         expected = CliTests.read_sibling_file("schemaorg.json")
         runner = CliRunner()
         with runner.isolated_filesystem():
-            with open("CITATION.cff", "w") as f:
+            with open("CITATION.cff", "w", encoding="utf8") as f:
                 f.write(cffstr)
             result = runner.invoke(cffconvert_cli, ["--outputformat", "schema.org",
                                                          "--outfile", "schemaorg.json"])
-            with open("schemaorg.json", "r") as f:
+            with open("schemaorg.json", "r", encoding="utf8") as f:
                 actual = f.read()
         self.assertEqual(result.exit_code, 0)
         self.assertEqual(expected, actual)

--- a/test/1.1.0/01/CodemetaObjectTest01.py
+++ b/test/1.1.0/01/CodemetaObjectTest01.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.1.0/01/EndnoteObjectTest01.py
+++ b/test/1.1.0/01/EndnoteObjectTest01.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.1.0/01/SchemaorgObjectTest01.py
+++ b/test/1.1.0/01/SchemaorgObjectTest01.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.1.0/01/ZenodoObjectTest01.py
+++ b/test/1.1.0/01/ZenodoObjectTest01.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -47,7 +47,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.1.0/02/ApalikeObjectTest02.py
+++ b/test/1.1.0/02/ApalikeObjectTest02.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.1.0/02/BibtexObjectTest02.py
+++ b/test/1.1.0/02/BibtexObjectTest02.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.1.0/02/CodemetaObjectTest02.py
+++ b/test/1.1.0/02/CodemetaObjectTest02.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.1.0/02/EndnoteObjectTest02.py
+++ b/test/1.1.0/02/EndnoteObjectTest02.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.1.0/02/SchemaorgObjectTest02.py
+++ b/test/1.1.0/02/SchemaorgObjectTest02.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.1.0/02/ZenodoObjectTest02.py
+++ b/test/1.1.0/02/ZenodoObjectTest02.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -47,7 +47,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.1.0/03/ApalikeObjectTest03.py
+++ b/test/1.1.0/03/ApalikeObjectTest03.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.1.0/03/BibtexObjectTest03.py
+++ b/test/1.1.0/03/BibtexObjectTest03.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.1.0/03/CodemetaObjectTest03.py
+++ b/test/1.1.0/03/CodemetaObjectTest03.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.1.0/03/EndnoteObjectTest03.py
+++ b/test/1.1.0/03/EndnoteObjectTest03.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.1.0/03/SchemaorgObjectTest03.py
+++ b/test/1.1.0/03/SchemaorgObjectTest03.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.1.0/03/ZenodoObjectTest03.py
+++ b/test/1.1.0/03/ZenodoObjectTest03.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -47,7 +47,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.1.0/04/ApalikeObjectTest04.py
+++ b/test/1.1.0/04/ApalikeObjectTest04.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.1.0/04/BibtexObjectTest04.py
+++ b/test/1.1.0/04/BibtexObjectTest04.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.1.0/04/CodemetaObjectTest04.py
+++ b/test/1.1.0/04/CodemetaObjectTest04.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.1.0/04/EndnoteObjectTest04.py
+++ b/test/1.1.0/04/EndnoteObjectTest04.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.1.0/04/SchemaorgObjectTest04.py
+++ b/test/1.1.0/04/SchemaorgObjectTest04.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.1.0/04/ZenodoObjectTest04.py
+++ b/test/1.1.0/04/ZenodoObjectTest04.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -47,7 +47,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.1.0/05/ApalikeObjectTest05.py
+++ b/test/1.1.0/05/ApalikeObjectTest05.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.1.0/05/BibtexObjectTest05.py
+++ b/test/1.1.0/05/BibtexObjectTest05.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.1.0/05/CodemetaObjectTest05.py
+++ b/test/1.1.0/05/CodemetaObjectTest05.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -78,7 +78,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.1.0/05/EndnoteObjectTest05.py
+++ b/test/1.1.0/05/EndnoteObjectTest05.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.1.0/05/SchemaorgObjectTest05.py
+++ b/test/1.1.0/05/SchemaorgObjectTest05.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -78,7 +78,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.1.0/05/ZenodoObjectTest05.py
+++ b/test/1.1.0/05/ZenodoObjectTest05.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -50,7 +50,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.1.0/06/ApalikeObjectTest06.py
+++ b/test/1.1.0/06/ApalikeObjectTest06.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.1.0/06/BibtexObjectTest06.py
+++ b/test/1.1.0/06/BibtexObjectTest06.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.1.0/06/CodemetaObjectTest06.py
+++ b/test/1.1.0/06/CodemetaObjectTest06.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.1.0/06/EndnoteObjectTest06.py
+++ b/test/1.1.0/06/EndnoteObjectTest06.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.1.0/06/SchemaorgObjectTest06.py
+++ b/test/1.1.0/06/SchemaorgObjectTest06.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -75,7 +75,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.1.0/06/ZenodoObjectTest06.py
+++ b/test/1.1.0/06/ZenodoObjectTest06.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -47,7 +47,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.1.0/07/ApalikeObjectTest07.py
+++ b/test/1.1.0/07/ApalikeObjectTest07.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.1.0/07/BibtexObjectTest07.py
+++ b/test/1.1.0/07/BibtexObjectTest07.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.1.0/07/CodemetaObjectTest07.py
+++ b/test/1.1.0/07/CodemetaObjectTest07.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -82,7 +82,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.1.0/07/EndnoteObjectTest07.py
+++ b/test/1.1.0/07/EndnoteObjectTest07.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.1.0/07/SchemaorgObjectTest07.py
+++ b/test/1.1.0/07/SchemaorgObjectTest07.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -82,7 +82,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.1.0/07/ZenodoObjectTest07.py
+++ b/test/1.1.0/07/ZenodoObjectTest07.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -51,7 +51,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/1.1.0/08/ApalikeObjectTest08.py
+++ b/test/1.1.0/08/ApalikeObjectTest08.py
@@ -8,7 +8,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/1.1.0/08/BibtexObjectTest08.py
+++ b/test/1.1.0/08/BibtexObjectTest08.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)
@@ -33,7 +33,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_bibtex = self.bo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_bibtex = f.read()
         self.assertEqual(actual_bibtex, expected_bibtex)
 

--- a/test/1.1.0/08/CodemetaObjectTest08.py
+++ b/test/1.1.0/08/CodemetaObjectTest08.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)
@@ -74,7 +74,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_codemeta = self.co.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_codemeta = f.read()
         self.assertEqual(actual_codemeta, expected_codemeta)
 

--- a/test/1.1.0/08/EndnoteObjectTest08.py
+++ b/test/1.1.0/08/EndnoteObjectTest08.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)
@@ -37,7 +37,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_endnote = self.eo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_endnote = f.read()
         self.assertEqual(actual_endnote, expected_endnote)
 

--- a/test/1.1.0/08/SchemaorgObjectTest08.py
+++ b/test/1.1.0/08/SchemaorgObjectTest08.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)
@@ -74,7 +74,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_schemaorg = self.so.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_schemaorg = f.read()
         self.assertEqual(actual_schemaorg, expected_schemaorg)
 

--- a/test/1.1.0/08/ZenodoObjectTest08.py
+++ b/test/1.1.0/08/ZenodoObjectTest08.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)
@@ -47,7 +47,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
     def test_print(self):
         actual_zenodo = self.zo.add_all().print()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             expected_zenodo = f.read()
         self.assertEqual(actual_zenodo, expected_zenodo)
 

--- a/test/test_consistent_versioning.py
+++ b/test/test_consistent_versioning.py
@@ -19,7 +19,7 @@ class ConsistencyTests(unittest.TestCase):
     def test_version_number_cff(self):
         # CITATION.cff content should have the same semver as setup.py / version.py
         fixture = os.path.join("CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cff_contents = f.read()
         actual_version = yaml.safe_load(cff_contents)["version"]
         self.assertEqual(self.expected_version, actual_version)
@@ -28,7 +28,7 @@ class ConsistencyTests(unittest.TestCase):
         # .zenodo.json content should not have any semver information, Zenodo retrieves this automatically from the
         # Zenodo-GtiHub integration
         fixture = os.path.join(".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             zenodojson_contents = f.read()
         self.assertFalse("version" in json.loads(zenodojson_contents).keys())
 
@@ -36,7 +36,7 @@ class ConsistencyTests(unittest.TestCase):
         # .zenodo.json content should not have any doi information, Zenodo retrieves this automatically from the
         # Zenodo-GtiHub integration
         fixture = os.path.join(".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             zenodojson_contents = f.read()
         self.assertFalse("doi" in json.loads(zenodojson_contents).keys())
 
@@ -44,7 +44,7 @@ class ConsistencyTests(unittest.TestCase):
         # .zenodo.json content should not have any date information, Zenodo retrieves this automatically from the
         # Zenodo-GtiHub integration
         fixture = os.path.join(".zenodo.json")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             zenodojson_contents = f.read()
         self.assertFalse("publication_date" in json.loads(zenodojson_contents).keys())
 

--- a/test/unsupported/01/ApalikeObjectTest01.py
+++ b/test/unsupported/01/ApalikeObjectTest01.py
@@ -9,7 +9,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/unsupported/01/BibtexObjectTest01.py
+++ b/test/unsupported/01/BibtexObjectTest01.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)

--- a/test/unsupported/01/CodemetaObjectTest01.py
+++ b/test/unsupported/01/CodemetaObjectTest01.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)

--- a/test/unsupported/01/EndnoteObjectTest01.py
+++ b/test/unsupported/01/EndnoteObjectTest01.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)

--- a/test/unsupported/01/SchemaorgObjectTest01.py
+++ b/test/unsupported/01/SchemaorgObjectTest01.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)

--- a/test/unsupported/01/ZenodoObjectTest01.py
+++ b/test/unsupported/01/ZenodoObjectTest01.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)

--- a/test/unsupported/02/ApalikeObjectTest02.py
+++ b/test/unsupported/02/ApalikeObjectTest02.py
@@ -9,7 +9,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/unsupported/02/BibtexObjectTest02.py
+++ b/test/unsupported/02/BibtexObjectTest02.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)

--- a/test/unsupported/02/CodemetaObjectTest02.py
+++ b/test/unsupported/02/CodemetaObjectTest02.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)

--- a/test/unsupported/02/EndnoteObjectTest02.py
+++ b/test/unsupported/02/EndnoteObjectTest02.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)

--- a/test/unsupported/02/SchemaorgObjectTest02.py
+++ b/test/unsupported/02/SchemaorgObjectTest02.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)

--- a/test/unsupported/02/ZenodoObjectTest02.py
+++ b/test/unsupported/02/ZenodoObjectTest02.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)

--- a/test/unsupported/03/ApalikeObjectTest03.py
+++ b/test/unsupported/03/ApalikeObjectTest03.py
@@ -9,7 +9,7 @@ class ApalikeObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.ao = ApalikeObject(cff_object, initialize_empty=True)

--- a/test/unsupported/03/BibtexObjectTest03.py
+++ b/test/unsupported/03/BibtexObjectTest03.py
@@ -9,7 +9,7 @@ class BibtexObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.bo = BibtexObject(cff_object, initialize_empty=True)

--- a/test/unsupported/03/CodemetaObjectTest03.py
+++ b/test/unsupported/03/CodemetaObjectTest03.py
@@ -9,7 +9,7 @@ class CodemetaObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.co = CodemetaObject(cff_object, initialize_empty=True)

--- a/test/unsupported/03/EndnoteObjectTest03.py
+++ b/test/unsupported/03/EndnoteObjectTest03.py
@@ -9,7 +9,7 @@ class EndnoteObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.eo = EndnoteObject(cff_object, initialize_empty=True)

--- a/test/unsupported/03/SchemaorgObjectTest03.py
+++ b/test/unsupported/03/SchemaorgObjectTest03.py
@@ -9,7 +9,7 @@ class SchemaorgObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.so = SchemaorgObject(cff_object, initialize_empty=True)

--- a/test/unsupported/03/ZenodoObjectTest03.py
+++ b/test/unsupported/03/ZenodoObjectTest03.py
@@ -9,7 +9,7 @@ class ZenodoObjectTest(Contract, unittest.TestCase):
 
     def setUp(self):
         fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
-        with open(fixture, "r") as f:
+        with open(fixture, "r", encoding="utf8") as f:
             cffstr = f.read()
             cff_object = yaml.safe_load(cffstr)
             self.zo = ZenodoObject(cff_object, initialize_empty=True)


### PR DESCRIPTION
This PR regex-replaces all calls to `with open()` to add `, encoding="utf8"` in a shot at fixing #153, and hopefully https://github.com/citation-file-format/citation-file-format/issues/137 in the process.

Still need to add some tests, once I've figured out how they work.