### PR TITLE
refactor authors creators

### DIFF
--- a/cffconvert/behavior_shared/bibtex.py
+++ b/cffconvert/behavior_shared/bibtex.py
@@ -108,7 +108,8 @@ class BibtexObjectShared:
     def add_author(self):
         authors_cff = self.cffobj.get('authors', list())
         authors_bibtex = [BibtexAuthor(a).as_string() for a in authors_cff]
-        self.author = 'author = {' + ' and '.join([a for a in authors_bibtex if a is not None]) + '}'
+        authors_bibtex_filtered = [a for a in authors_bibtex if a is not None]
+        self.author = 'author = {' + ' and '.join(authors_bibtex_filtered) + '}'
         return self
 
     @abstractmethod

--- a/test/1.0.3/01/BibtexObjectTest01.py
+++ b/test/1.0.3/01/BibtexObjectTest01.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.0.3/01/bibtex.bib
+++ b/test/1.0.3/01/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.0.3/02/BibtexObjectTest02.py
+++ b/test/1.0.3/02/BibtexObjectTest02.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Gonzalo Fernández de Córdoba Jr.}'
+        assert bibtex_object.author == 'author = {Fernández de Córdoba Jr., Gonzalo}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.0.3/02/bibtex.bib
+++ b/test/1.0.3/02/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Gonzalo Fernández de Córdoba Jr.},
+author = {Fernández de Córdoba Jr., Gonzalo},
 month = {12},
 title = {example title},
 year = {1999}

--- a/test/1.0.3/03/BibtexObjectTest03.py
+++ b/test/1.0.3/03/BibtexObjectTest03.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jisk Attema and Faruk Diblen}'
+        assert bibtex_object.author == 'author = {Attema, Jisk and Diblen, Faruk}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.0.3/03/bibtex.bib
+++ b/test/1.0.3/03/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jisk Attema and Faruk Diblen},
+author = {Attema, Jisk and Diblen, Faruk},
 doi = {10.5281/zenodo.1003346},
 month = {10},
 title = {spot},

--- a/test/1.0.3/04/BibtexObjectTest04.py
+++ b/test/1.0.3/04/BibtexObjectTest04.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver and Stefan Verhoeven and Stephan Druskat}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom and Verhoeven, Stefan and Druskat, Stephan}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.0.3/04/bibtex.bib
+++ b/test/1.0.3/04/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver and Stefan Verhoeven and Stephan Druskat},
+author = {Spaaks, Jurriaan H. and Klaver, Tom and Verhoeven, Stefan and Druskat, Stephan},
 doi = {10.5281/zenodo.1162057},
 month = {7},
 title = {cffconvert},

--- a/test/1.0.3/05/BibtexObjectTest05.py
+++ b/test/1.0.3/05/BibtexObjectTest05.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver and Stefan Verhoeven}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom and Verhoeven, Stefan}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.0.3/05/bibtex.bib
+++ b/test/1.0.3/05/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver and Stefan Verhoeven},
+author = {Spaaks, Jurriaan H. and Klaver, Tom and Verhoeven, Stefan},
 doi = {10.5281/zenodo.1162057},
 month = {5},
 title = {cffconvert},

--- a/test/1.1.0/01/BibtexObjectTest01.py
+++ b/test/1.1.0/01/BibtexObjectTest01.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.1.0/01/bibtex.bib
+++ b/test/1.1.0/01/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.1.0/02/BibtexObjectTest02.py
+++ b/test/1.1.0/02/BibtexObjectTest02.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.1.0/02/bibtex.bib
+++ b/test/1.1.0/02/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.1.0/03/BibtexObjectTest03.py
+++ b/test/1.1.0/03/BibtexObjectTest03.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.1.0/03/bibtex.bib
+++ b/test/1.1.0/03/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.1.0/04/BibtexObjectTest04.py
+++ b/test/1.1.0/04/BibtexObjectTest04.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.1.0/04/bibtex.bib
+++ b/test/1.1.0/04/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.1.0/05/BibtexObjectTest05.py
+++ b/test/1.1.0/05/BibtexObjectTest05.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver and mysteryauthor}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.1.0/05/bibtex.bib
+++ b/test/1.1.0/05/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver and mysteryauthor},
+author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.1.0/06/BibtexObjectTest06.py
+++ b/test/1.1.0/06/BibtexObjectTest06.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.1.0/06/bibtex.bib
+++ b/test/1.1.0/06/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.1.0/07/BibtexObjectTest07.py
+++ b/test/1.1.0/07/BibtexObjectTest07.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver and mysteryauthor}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.1.0/07/bibtex.bib
+++ b/test/1.1.0/07/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver and mysteryauthor},
+author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.1.0/08/BibtexObjectTest08.py
+++ b/test/1.1.0/08/BibtexObjectTest08.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Steven Van Zandt and Steven van Zandt}'
+        assert bibtex_object.author == 'author = {Van Zandt, Steven and van Zandt, Steven}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.1.0/08/bibtex.bib
+++ b/test/1.1.0/08/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Steven Van Zandt and Steven van Zandt},
+author = {Van Zandt, Steven and van Zandt, Steven},
 month = {1},
 title = {cff-converter-python},
 year = {2018}

--- a/test/1.2.0/01/BibtexObjectTest01.py
+++ b/test/1.2.0/01/BibtexObjectTest01.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.2.0/01/bibtex.bib
+++ b/test/1.2.0/01/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.2.0/02/BibtexObjectTest02.py
+++ b/test/1.2.0/02/BibtexObjectTest02.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.2.0/02/bibtex.bib
+++ b/test/1.2.0/02/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.2.0/03/BibtexObjectTest03.py
+++ b/test/1.2.0/03/BibtexObjectTest03.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.2.0/03/bibtex.bib
+++ b/test/1.2.0/03/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.2.0/04/BibtexObjectTest04.py
+++ b/test/1.2.0/04/BibtexObjectTest04.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.2.0/04/bibtex.bib
+++ b/test/1.2.0/04/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.2.0/05/BibtexObjectTest05.py
+++ b/test/1.2.0/05/BibtexObjectTest05.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver and mysteryauthor}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.2.0/05/bibtex.bib
+++ b/test/1.2.0/05/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver and mysteryauthor},
+author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.2.0/06/BibtexObjectTest06.py
+++ b/test/1.2.0/06/BibtexObjectTest06.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.2.0/06/bibtex.bib
+++ b/test/1.2.0/06/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver},
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.2.0/07/BibtexObjectTest07.py
+++ b/test/1.2.0/07/BibtexObjectTest07.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Jurriaan H. Spaaks and Tom Klaver and mysteryauthor}'
+        assert bibtex_object.author == 'author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.2.0/07/bibtex.bib
+++ b/test/1.2.0/07/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Jurriaan H. Spaaks and Tom Klaver and mysteryauthor},
+author = {Spaaks, Jurriaan H. and Klaver, Tom and mysteryauthor},
 doi = {10.5281/zenodo.1162057},
 month = {1},
 title = {cff-converter-python},

--- a/test/1.2.0/08/BibtexObjectTest08.py
+++ b/test/1.2.0/08/BibtexObjectTest08.py
@@ -18,7 +18,7 @@ class BibtexObjectTest(Contract):
 
     def test_author(self, bibtex_object):
         bibtex_object.add_author()
-        assert bibtex_object.author == 'author = {Steven Van Zandt and Steven van Zandt}'
+        assert bibtex_object.author == 'author = {Van Zandt, Steven and van Zandt, Steven}'
 
     def test_check_cffobj(self, bibtex_object):
         bibtex_object.check_cffobj()

--- a/test/1.2.0/08/bibtex.bib
+++ b/test/1.2.0/08/bibtex.bib
@@ -1,5 +1,5 @@
 @misc{YourReferenceHere,
-author = {Steven Van Zandt and Steven van Zandt},
+author = {Van Zandt, Steven and van Zandt, Steven},
 month = {1},
 title = {cff-converter-python},
 year = {2018}

--- a/test/1.2.0/09/BibtexObjectTest09.py
+++ b/test/1.2.0/09/BibtexObjectTest09.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {van der Vaart III, Rafael}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/09/CITATION.cff
+++ b/test/1.2.0/09/CITATION.cff
@@ -1,0 +1,9 @@
+authors:
+  - given-names: Rafael
+    name-particle: van der
+    family-names: Vaart
+    name-suffix: III
+    alias: Rafa
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/09/CitationTest09.py
+++ b/test/1.2.0/09/CitationTest09.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/09/bibtex.bib
+++ b/test/1.2.0/09/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {van der Vaart III, Rafael},
+title = {the title}
+}

--- a/test/1.2.0/10/BibtexObjectTest10.py
+++ b/test/1.2.0/10/BibtexObjectTest10.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {van der Vaart III, Rafael}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/10/CITATION.cff
+++ b/test/1.2.0/10/CITATION.cff
@@ -1,0 +1,8 @@
+authors:
+  - given-names: Rafael
+    name-particle: van der
+    family-names: Vaart
+    name-suffix: III
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/10/CitationTest10.py
+++ b/test/1.2.0/10/CitationTest10.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/10/bibtex.bib
+++ b/test/1.2.0/10/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {van der Vaart III, Rafael},
+title = {the title}
+}

--- a/test/1.2.0/11/BibtexObjectTest11.py
+++ b/test/1.2.0/11/BibtexObjectTest11.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {Rafa}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/11/CITATION.cff
+++ b/test/1.2.0/11/CITATION.cff
@@ -1,0 +1,6 @@
+authors:
+  - given-names: Rafael
+    alias: Rafa
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/11/CitationTest11.py
+++ b/test/1.2.0/11/CitationTest11.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/11/bibtex.bib
+++ b/test/1.2.0/11/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {Rafa},
+title = {the title}
+}

--- a/test/1.2.0/12/BibtexObjectTest12.py
+++ b/test/1.2.0/12/BibtexObjectTest12.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {The soccer team members}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/12/CITATION.cff
+++ b/test/1.2.0/12/CITATION.cff
@@ -1,0 +1,5 @@
+authors:
+  - name: The soccer team members
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/12/CitationTest12.py
+++ b/test/1.2.0/12/CitationTest12.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/12/bibtex.bib
+++ b/test/1.2.0/12/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {The soccer team members},
+title = {the title}
+}

--- a/test/1.2.0/13/BibtexObjectTest13.py
+++ b/test/1.2.0/13/BibtexObjectTest13.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {Rafael}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/13/CITATION.cff
+++ b/test/1.2.0/13/CITATION.cff
@@ -1,0 +1,5 @@
+authors:
+  - given-names: Rafael
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/13/CitationTest13.py
+++ b/test/1.2.0/13/CitationTest13.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/13/bibtex.bib
+++ b/test/1.2.0/13/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {Rafael},
+title = {the title}
+}

--- a/test/1.2.0/14/BibtexObjectTest14.py
+++ b/test/1.2.0/14/BibtexObjectTest14.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {van der Vaart III}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/14/CITATION.cff
+++ b/test/1.2.0/14/CITATION.cff
@@ -1,0 +1,8 @@
+authors:
+  - name-particle: van der
+    family-names: Vaart
+    name-suffix: III
+    alias: Rafa
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/14/CitationTest14.py
+++ b/test/1.2.0/14/CitationTest14.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/14/bibtex.bib
+++ b/test/1.2.0/14/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {van der Vaart III},
+title = {the title}
+}

--- a/test/1.2.0/15/BibtexObjectTest15.py
+++ b/test/1.2.0/15/BibtexObjectTest15.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {van der Vaart III}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/15/CITATION.cff
+++ b/test/1.2.0/15/CITATION.cff
@@ -1,0 +1,7 @@
+authors:
+  - name-particle: van der
+    family-names: Vaart
+    name-suffix: III
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/15/CitationTest15.py
+++ b/test/1.2.0/15/CitationTest15.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/15/bibtex.bib
+++ b/test/1.2.0/15/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {van der Vaart III},
+title = {the title}
+}

--- a/test/1.2.0/16/BibtexObjectTest16.py
+++ b/test/1.2.0/16/BibtexObjectTest16.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {The soccer team members}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/16/CITATION.cff
+++ b/test/1.2.0/16/CITATION.cff
@@ -1,0 +1,6 @@
+authors:
+  - name: The soccer team members
+    alias: Rafa
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/16/CitationTest16.py
+++ b/test/1.2.0/16/CitationTest16.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/16/bibtex.bib
+++ b/test/1.2.0/16/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {The soccer team members},
+title = {the title}
+}

--- a/test/1.2.0/17/BibtexObjectTest17.py
+++ b/test/1.2.0/17/BibtexObjectTest17.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {The soccer team members}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/17/CITATION.cff
+++ b/test/1.2.0/17/CITATION.cff
@@ -1,0 +1,5 @@
+authors:
+  - name: The soccer team members
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/17/CitationTest17.py
+++ b/test/1.2.0/17/CitationTest17.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/17/bibtex.bib
+++ b/test/1.2.0/17/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {The soccer team members},
+title = {the title}
+}

--- a/test/1.2.0/18/BibtexObjectTest18.py
+++ b/test/1.2.0/18/BibtexObjectTest18.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {van der Vaart III, Rafael and dos Santos Aveiro, Cristiano Ronaldo}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/18/CITATION.cff
+++ b/test/1.2.0/18/CITATION.cff
@@ -1,0 +1,12 @@
+authors:
+  - given-names: Rafael
+    name-particle: van der
+    family-names: Vaart
+    name-suffix: III
+    alias: Rafa
+  - given-names: Cristiano Ronaldo
+    family-names: dos Santos Aveiro
+    alias: Ronaldo
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/18/CitationTest18.py
+++ b/test/1.2.0/18/CitationTest18.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/18/bibtex.bib
+++ b/test/1.2.0/18/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {van der Vaart III, Rafael and dos Santos Aveiro, Cristiano Ronaldo},
+title = {the title}
+}

--- a/test/1.2.0/19/BibtexObjectTest19.py
+++ b/test/1.2.0/19/BibtexObjectTest19.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {van der Vaart III, Rafael and dos Santos Aveiro, Cristiano Ronaldo}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/19/CITATION.cff
+++ b/test/1.2.0/19/CITATION.cff
@@ -1,0 +1,10 @@
+authors:
+  - given-names: Rafael
+    name-particle: van der
+    family-names: Vaart
+    name-suffix: III
+  - given-names: Cristiano Ronaldo
+    family-names: dos Santos Aveiro
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/19/CitationTest19.py
+++ b/test/1.2.0/19/CitationTest19.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/19/bibtex.bib
+++ b/test/1.2.0/19/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {van der Vaart III, Rafael and dos Santos Aveiro, Cristiano Ronaldo},
+title = {the title}
+}

--- a/test/1.2.0/20/BibtexObjectTest20.py
+++ b/test/1.2.0/20/BibtexObjectTest20.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {Rafa and Ronaldo}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/20/CITATION.cff
+++ b/test/1.2.0/20/CITATION.cff
@@ -1,0 +1,8 @@
+authors:
+  - given-names: Rafael
+    alias: Rafa
+  - given-names: Cristiano Ronaldo
+    alias: Ronaldo
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/20/CitationTest20.py
+++ b/test/1.2.0/20/CitationTest20.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/20/bibtex.bib
+++ b/test/1.2.0/20/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {Rafa and Ronaldo},
+title = {the title}
+}

--- a/test/1.2.0/21/BibtexObjectTest21.py
+++ b/test/1.2.0/21/BibtexObjectTest21.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {The soccer team members and The support staff}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/21/CITATION.cff
+++ b/test/1.2.0/21/CITATION.cff
@@ -1,0 +1,6 @@
+authors:
+  - name: The soccer team members
+  - name: The support staff
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/21/CitationTest21.py
+++ b/test/1.2.0/21/CitationTest21.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/21/bibtex.bib
+++ b/test/1.2.0/21/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {The soccer team members and The support staff},
+title = {the title}
+}

--- a/test/1.2.0/22/BibtexObjectTest22.py
+++ b/test/1.2.0/22/BibtexObjectTest22.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {Rafael and Cristiano Ronaldo}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/22/CITATION.cff
+++ b/test/1.2.0/22/CITATION.cff
@@ -1,0 +1,6 @@
+authors:
+  - given-names: Rafael
+  - given-names: Cristiano Ronaldo
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/22/CitationTest22.py
+++ b/test/1.2.0/22/CitationTest22.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/22/bibtex.bib
+++ b/test/1.2.0/22/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {Rafael and Cristiano Ronaldo},
+title = {the title}
+}

--- a/test/1.2.0/23/BibtexObjectTest23.py
+++ b/test/1.2.0/23/BibtexObjectTest23.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {van der Vaart III and dos Santos Aveiro}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/23/CITATION.cff
+++ b/test/1.2.0/23/CITATION.cff
@@ -1,0 +1,10 @@
+authors:
+  - name-particle: van der
+    family-names: Vaart
+    name-suffix: III
+    alias: Rafa
+  - family-names: dos Santos Aveiro
+    alias: Ronaldo
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/23/CitationTest23.py
+++ b/test/1.2.0/23/CitationTest23.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/23/bibtex.bib
+++ b/test/1.2.0/23/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {van der Vaart III and dos Santos Aveiro},
+title = {the title}
+}

--- a/test/1.2.0/24/BibtexObjectTest24.py
+++ b/test/1.2.0/24/BibtexObjectTest24.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {van der Vaart III and dos Santos Aveiro}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/24/CITATION.cff
+++ b/test/1.2.0/24/CITATION.cff
@@ -1,0 +1,8 @@
+authors:
+  - name-particle: van der
+    family-names: Vaart
+    name-suffix: III
+  - family-names: dos Santos Aveiro
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/24/CitationTest24.py
+++ b/test/1.2.0/24/CitationTest24.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/24/bibtex.bib
+++ b/test/1.2.0/24/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {van der Vaart III and dos Santos Aveiro},
+title = {the title}
+}

--- a/test/1.2.0/25/BibtexObjectTest25.py
+++ b/test/1.2.0/25/BibtexObjectTest25.py
@@ -1,0 +1,52 @@
+import os
+import pytest
+from test.contracts.BibtexObject import Contract
+from cffconvert.behavior_1_2_x.bibtex import BibtexObject
+from cffconvert import Citation
+
+
+@pytest.fixture(scope="module")
+def bibtex_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "r") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return BibtexObject(citation.cffobj, initialize_empty=True)
+
+
+class BibtexObjectTest(Contract):
+
+    def test_author(self, bibtex_object):
+        bibtex_object.add_author()
+        assert bibtex_object.author == 'author = {The soccer team members and The trainers}'
+
+    def test_check_cffobj(self, bibtex_object):
+        bibtex_object.check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self, bibtex_object):
+        bibtex_object.add_doi()
+        assert bibtex_object.doi is None
+
+    def test_month(self, bibtex_object):
+        bibtex_object.add_month()
+        assert bibtex_object.month is None
+
+    def test_print(self, bibtex_object):
+        actual_bibtex = bibtex_object.add_all().print()
+        fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
+        with open(fixture, "r") as f:
+            expected_bibtex = f.read()
+        assert actual_bibtex == expected_bibtex
+
+    def test_title(self, bibtex_object):
+        bibtex_object.add_title()
+        assert bibtex_object.title == 'title = {the title}'
+
+    def test_url(self, bibtex_object):
+        bibtex_object.add_url()
+        assert bibtex_object.url is None
+
+    def test_year(self, bibtex_object):
+        bibtex_object.add_year()
+        assert bibtex_object.year is None

--- a/test/1.2.0/25/CITATION.cff
+++ b/test/1.2.0/25/CITATION.cff
@@ -1,0 +1,8 @@
+authors:
+  - name: The soccer team members
+    alias: Rafa
+  - name: The trainers
+    alias: coach
+cff-version: "1.2.0"
+message: "test of author inputs"
+title: the title

--- a/test/1.2.0/25/CitationTest25.py
+++ b/test/1.2.0/25/CitationTest25.py
@@ -1,0 +1,23 @@
+import os
+import pytest
+from cffconvert.citation import Citation
+
+
+@pytest.fixture(scope="module")
+def citation():
+    p = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(p, "rt", encoding="utf-8") as fid:
+        cffstr = fid.read()
+        return Citation(cffstr)
+
+
+def test_cffobj(citation):
+    pass
+
+
+def test_cffversion(citation):
+    assert citation.cffversion == "1.2.0"
+
+
+def test_validate(citation):
+    citation.validate()

--- a/test/1.2.0/25/bibtex.bib
+++ b/test/1.2.0/25/bibtex.bib
@@ -1,0 +1,4 @@
+@misc{YourReferenceHere,
+author = {The soccer team members and The trainers},
+title = {the title}
+}


### PR DESCRIPTION
This PR explores an approach to construct bibtex names given a variety of inputs.

The approach uses a dictionary to map the state of a few inputs (`has_given_names`, `has_family_names`, `has_alias`  and `has_name`) to dedicated functions for the various behaviors that we want https://github.com/citation-file-format/cff-converter-python/pull/186/files#diff-6f445b23f96ee76e5ae1b2c4da320f2d9c711dd5963e3c6e3a2e6dba472220cbR10-R32.

I added a bunch of tests in `test/1.2.0/09` through `test/1.2.0/17` with various combinations of properties for an item with just a single author; `test/1.2.0/17` through `test/1.2.0/25` are their equivalent but with 2 items in the author list.

Could be useful for https://github.com/citation-file-format/citation-file-format/issues/330 as well

Refs:
- #179
- #178 
- #177
- #156 
- #142
