### PR TITLE
Schemaorg expansion

### DIFF
--- a/cffconvert/behavior_shared/schemaorg_author.py
+++ b/cffconvert/behavior_shared/schemaorg_author.py
@@ -6,58 +6,58 @@ class SchemaorgAuthorShared:
     def __init__(self, author_cff):
         self._author_cff = author_cff
         self._behaviors = {
-            'GFANAO': self._from_given_and_last_and_affiliation_and_orcid,
-            'GFANA.': self._from_given_and_last_and_affiliation,
-            'GFAN.O': self._from_given_and_last_and_orcid,
-            'GFAN..': self._from_given_and_last,
-            'GFA.AO': self._from_given_and_last_and_affiliation_and_orcid,
-            'GFA.A.': self._from_given_and_last_and_affiliation,
-            'GFA..O': self._from_given_and_last_and_orcid,
-            'GFA...': self._from_given_and_last,
-            'GF.NAO': self._from_given_and_last_and_affiliation_and_orcid,
-            'GF.NA.': self._from_given_and_last_and_affiliation,
-            'GF.N.O': self._from_given_and_last_and_orcid,
-            'GF.N..': self._from_given_and_last,
+            'GFANAO': self._from_given_and_last_and_alias_and_name_and_affiliation_and_orcid,
+            'GFANA.': self._from_given_and_last_and_alias_and_name_and_affiliation,
+            'GFAN.O': self._from_given_and_last_and_alias_and_name_and_orcid,
+            'GFAN..': self._from_given_and_last_and_alias_and_name,
+            'GFA.AO': self._from_given_and_last_and_alias_and_affiliation_and_orcid,
+            'GFA.A.': self._from_given_and_last_and_alias_and_affiliation,
+            'GFA..O': self._from_given_and_last_and_alias_and_orcid,
+            'GFA...': self._from_given_and_last_and_alias,
+            'GF.NAO': self._from_given_and_last_and_name_and_affiliation_and_orcid,
+            'GF.NA.': self._from_given_and_last_and_name_and_affiliation,
+            'GF.N.O': self._from_given_and_last_and_name_and_orcid,
+            'GF.N..': self._from_given_and_last_and_name,
             'GF..AO': self._from_given_and_last_and_affiliation_and_orcid,
             'GF..A.': self._from_given_and_last_and_affiliation,
             'GF...O': self._from_given_and_last_and_orcid,
             'GF....': self._from_given_and_last,
-            'G.ANAO': self._from_given_and_affiliation_and_orcid,
-            'G.ANA.': self._from_given_and_affiliation,
-            'G.AN.O': self._from_given_and_orcid,
-            'G.AT..': self._from_given,
-            'G.A.AO': self._from_given_and_affiliation_and_orcid,
-            'G.A.A.': self._from_given_and_affiliation,
-            'G.A..O': self._from_given_and_orcid,
-            'G.A...': self._from_given,
-            'G..NAO': self._from_given_and_affiliation_and_orcid,
-            'G..NA.': self._from_given_and_affiliation,
-            'G..N.O': self._from_given_and_orcid,
-            'G..N..': self._from_given,
+            'G.ANAO': self._from_given_and_alias_and_name_and_affiliation_and_orcid,
+            'G.ANA.': self._from_given_and_alias_and_name_and_affiliation,
+            'G.AN.O': self._from_given_and_alias_and_name_and_orcid,
+            'G.AN..': self._from_given_and_alias_and_name,
+            'G.A.AO': self._from_given_and_alias_and_affiliation_and_orcid,
+            'G.A.A.': self._from_given_and_alias_and_affiliation,
+            'G.A..O': self._from_given_and_alias_and_orcid,
+            'G.A...': self._from_given_and_alias,
+            'G..NAO': self._from_given_and_name_and_affiliation_and_orcid,
+            'G..NA.': self._from_given_and_name_and_affiliation,
+            'G..N.O': self._from_given_and_name_and_orcid,
+            'G..N..': self._from_given_and_name,
             'G...AO': self._from_given_and_affiliation_and_orcid,
             'G...A.': self._from_given_and_affiliation,
             'G....O': self._from_given_and_orcid,
             'G.....': self._from_given,
-            '.FANAO': self._from_last_and_affiliation_and_orcid,
-            '.FANA.': self._from_last_and_affiliation,
-            '.FAN.O': self._from_last_and_orcid,
-            '.FAN..': self._from_last,
-            '.FA.AO': self._from_last_and_affiliation_and_orcid,
-            '.FA.A.': self._from_last_and_affiliation,
-            '.FA..O': self._from_last_and_orcid,
-            '.FA...': self._from_last,
-            '.F.NAO': self._from_last_and_affiliation_and_orcid,
-            '.F.NA.': self._from_last_and_affiliation,
-            '.F.N.O': self._from_last_and_orcid,
-            '.F.N..': self._from_last,
+            '.FANAO': self._from_last_and_alias_and_name_and_affiliation_and_orcid,
+            '.FANA.': self._from_last_and_alias_and_name_and_affiliation,
+            '.FAN.O': self._from_last_and_alias_and_name_and_orcid,
+            '.FAN..': self._from_last_and_alias_and_name,
+            '.FA.AO': self._from_last_and_alias_and_affiliation_and_orcid,
+            '.FA.A.': self._from_last_and_alias_and_affiliation,
+            '.FA..O': self._from_last_and_alias_and_orcid,
+            '.FA...': self._from_last_and_alias,
+            '.F.NAO': self._from_last_and_name_and_affiliation_and_orcid,
+            '.F.NA.': self._from_last_and_name_and_affiliation,
+            '.F.N.O': self._from_last_and_name_and_orcid,
+            '.F.N..': self._from_last_and_name,
             '.F..AO': self._from_last_and_affiliation_and_orcid,
             '.F..A.': self._from_last_and_affiliation,
             '.F...O': self._from_last_and_orcid,
             '.F....': self._from_last,
-            '..ANAO': self._from_alias_and_affiliation_and_orcid,
-            '..ANA.': self._from_alias_and_affiliation,
-            '..AN.O': self._from_alias_and_orcid,
-            '..AN..': self._from_alias,
+            '..ANAO': self._from_alias_and_name_and_affiliation_and_orcid,
+            '..ANA.': self._from_alias_and_name_and_affiliation,
+            '..AN.O': self._from_alias_and_name_and_orcid,
+            '..AN..': self._from_alias_and_name,
             '..A.AO': self._from_alias_and_affiliation_and_orcid,
             '..A.A.': self._from_alias_and_affiliation,
             '..A..O': self._from_alias_and_orcid,
@@ -98,35 +98,73 @@ class SchemaorgAuthorShared:
     def _from_alias(self):
         return {
             '@type': 'Person',
-            'name': self._author_cff.get('alias')
+            'alternateName': self._author_cff.get('alias')
         }
 
     def _from_alias_and_affiliation(self):
         return {
             '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
             'affiliation': {
                 '@type': 'Organization',
                 'legalName': self._author_cff.get('affiliation')
-            },
-            'name': self._author_cff.get('alias')
+            }
         }
 
     def _from_alias_and_affiliation_and_orcid(self):
         return {
             '@id': self._author_cff.get('orcid'),
             '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            }
+        }
+
+    def _from_alias_and_name_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
             'affiliation': {
                 '@type': 'Organization',
                 'legalName': self._author_cff.get('affiliation')
             },
-            'name': self._author_cff.get('alias')
+            'alternateName': self._author_cff.get('alias'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_alias_and_name_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_alias_and_name_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_alias_and_name(self):
+        return {
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'name': self._author_cff.get('name')
         }
 
     def _from_alias_and_orcid(self):
         return {
             '@id': self._author_cff.get('orcid'),
             '@type': 'Person',
-            'name': self._author_cff.get('alias')
+            'alternateName': self._author_cff.get('alias')
         }
 
     def _from_given(self):
@@ -153,6 +191,91 @@ class SchemaorgAuthorShared:
                 '@type': 'Organization',
                 'legalName': self._author_cff.get('affiliation')
             },
+            'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_alias(self):
+        return {
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_alias_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_alias_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_alias_and_name_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_alias_and_name_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_alias_and_name_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_alias_and_name(self):
+        return {
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_alias_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
             'givenName': self._author_cff.get('given-names')
         }
 
@@ -186,12 +309,180 @@ class SchemaorgAuthorShared:
             'givenName': self._author_cff.get('given-names')
         }
 
+    def _from_given_and_last_and_alias(self):
+        return {
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_last_and_alias_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_last_and_alias_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_last_and_alias_and_name_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_last_and_alias_and_name_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_last_and_alias_and_name_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_last_and_alias_and_name(self):
+        return {
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_last_and_alias_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_last_and_name_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_last_and_name_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_last_and_name_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_last_and_name(self):
+        return {
+            '@type': 'Person',
+            'familyName': self._get_full_last_name(),
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
     def _from_given_and_last_and_orcid(self):
         return {
             '@id': self._author_cff.get('orcid'),
             '@type': 'Person',
             'familyName': self._get_full_last_name(),
             'givenName': self._author_cff.get('given-names')
+        }
+
+    def _from_given_and_name_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_name_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_name_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_given_and_name(self):
+        return {
+            '@type': 'Person',
+            'givenName': self._author_cff.get('given-names'),
+            'name': self._author_cff.get('name')
         }
 
     def _from_given_and_orcid(self):
@@ -226,6 +517,124 @@ class SchemaorgAuthorShared:
                 'legalName': self._author_cff.get('affiliation')
             },
             'familyName': self._get_full_last_name()
+        }
+
+    def _from_last_and_alias(self):
+        return {
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name()
+        }
+
+    def _from_last_and_alias_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name()
+        }
+
+    def _from_last_and_alias_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name()
+        }
+
+    def _from_last_and_alias_and_name_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_last_and_alias_and_name_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_last_and_alias_and_name_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_last_and_alias_and_name(self):
+        return {
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name(),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_last_and_alias_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'alternateName': self._author_cff.get('alias'),
+            'familyName': self._get_full_last_name()
+        }
+
+    def _from_last_and_name_and_affiliation_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'familyName': self._get_full_last_name(),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_last_and_name_and_affiliation(self):
+        return {
+            '@type': 'Person',
+            'affiliation': {
+                '@type': 'Organization',
+                'legalName': self._author_cff.get('affiliation')
+            },
+            'familyName': self._get_full_last_name(),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_last_and_name_and_orcid(self):
+        return {
+            '@id': self._author_cff.get('orcid'),
+            '@type': 'Person',
+            'familyName': self._get_full_last_name(),
+            'name': self._author_cff.get('name')
+        }
+
+    def _from_last_and_name(self):
+        return {
+            '@type': 'Person',
+            'familyName': self._get_full_last_name(),
+            'name': self._author_cff.get('name')
         }
 
     def _from_last_and_orcid(self):

--- a/test/1.1.0/05/codemeta.json
+++ b/test/1.1.0/05/codemeta.json
@@ -8,6 +8,7 @@
         "@type": "Organization",
         "legalName": "Netherlands eScience Center"
       },
+      "alternateName": "jspaaks",
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
     },
@@ -22,7 +23,7 @@
     },
     {
       "@type": "Person",
-      "name": "mysteryauthor"
+      "alternateName": "mysteryauthor"
     }
   ],
   "codeRepository": "https://github.com/citation-file-format/cff-converter-python",

--- a/test/1.1.0/05/schemaorg.json
+++ b/test/1.1.0/05/schemaorg.json
@@ -8,6 +8,7 @@
         "@type": "Organization",
         "legalName": "Netherlands eScience Center"
       },
+      "alternateName": "jspaaks",
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
     },
@@ -22,7 +23,7 @@
     },
     {
       "@type": "Person",
-      "name": "mysteryauthor"
+      "alternateName": "mysteryauthor"
     }
   ],
   "codeRepository": "https://github.com/citation-file-format/cff-converter-python",

--- a/test/1.1.0/05/test_1_1_0__05_codemeta_object.py
+++ b/test/1.1.0/05/test_1_1_0__05_codemeta_object.py
@@ -28,6 +28,7 @@ class TestCodemetaObject(Contract):
                 "@type": "Organization",
                 "legalName": "Netherlands eScience Center"
             },
+            "alternateName": "jspaaks",
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
         }, {
@@ -40,7 +41,7 @@ class TestCodemetaObject(Contract):
             "givenName": "Tom"
         }, {
             "@type": "Person",
-            "name": "mysteryauthor"
+            "alternateName": "mysteryauthor"
         }]
         assert codemeta_object.author == expected_author
 

--- a/test/1.1.0/05/test_1_1_0__05_schemaorg_object.py
+++ b/test/1.1.0/05/test_1_1_0__05_schemaorg_object.py
@@ -28,6 +28,7 @@ class TestSchemaorgObject(Contract):
                 "@type": "Organization",
                 "legalName": "Netherlands eScience Center"
             },
+            "alternateName": "jspaaks",
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
         }, {
@@ -40,7 +41,7 @@ class TestSchemaorgObject(Contract):
             "givenName": "Tom"
         }, {
             "@type": "Person",
-            "name": "mysteryauthor"
+            "alternateName": "mysteryauthor"
         }]
         assert schemaorg_object.author == expected_author
 

--- a/test/1.1.0/06/codemeta.json
+++ b/test/1.1.0/06/codemeta.json
@@ -8,6 +8,7 @@
         "@type": "Organization",
         "legalName": "Netherlands eScience Center"
       },
+      "alternateName": "jspaaks",
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
     },

--- a/test/1.1.0/06/schemaorg.json
+++ b/test/1.1.0/06/schemaorg.json
@@ -8,6 +8,7 @@
         "@type": "Organization",
         "legalName": "Netherlands eScience Center"
       },
+      "alternateName": "jspaaks",
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
     },

--- a/test/1.1.0/06/test_1_1_0__06_codemeta_object.py
+++ b/test/1.1.0/06/test_1_1_0__06_codemeta_object.py
@@ -28,6 +28,7 @@ class TestCodemetaObject(Contract):
                 "@type": "Organization",
                 "legalName": "Netherlands eScience Center"
             },
+            "alternateName": "jspaaks",
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
         }, {

--- a/test/1.1.0/06/test_1_1_0__06_schemaorg_object.py
+++ b/test/1.1.0/06/test_1_1_0__06_schemaorg_object.py
@@ -28,6 +28,7 @@ class TestSchemaorgObject(Contract):
                 "@type": "Organization",
                 "legalName": "Netherlands eScience Center"
             },
+            "alternateName": "jspaaks",
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
         }, {

--- a/test/1.1.0/07/codemeta.json
+++ b/test/1.1.0/07/codemeta.json
@@ -8,6 +8,7 @@
         "@type": "Organization",
         "legalName": "Netherlands eScience Center"
       },
+      "alternateName": "jspaaks",
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
     },
@@ -26,7 +27,7 @@
         "@type": "Organization",
         "legalName": "MyAffiliation"
       },
-      "name": "mysteryauthor"
+      "alternateName": "mysteryauthor"
     }
   ],
   "codeRepository": "https://github.com/citation-file-format/cff-converter-python",

--- a/test/1.1.0/07/schemaorg.json
+++ b/test/1.1.0/07/schemaorg.json
@@ -8,6 +8,7 @@
         "@type": "Organization",
         "legalName": "Netherlands eScience Center"
       },
+      "alternateName": "jspaaks",
       "familyName": "Spaaks",
       "givenName": "Jurriaan H."
     },
@@ -26,7 +27,7 @@
         "@type": "Organization",
         "legalName": "MyAffiliation"
       },
-      "name": "mysteryauthor"
+      "alternateName": "mysteryauthor"
     }
   ],
   "codeRepository": "https://github.com/citation-file-format/cff-converter-python",

--- a/test/1.1.0/07/test_1_1_0__07_codemeta_object.py
+++ b/test/1.1.0/07/test_1_1_0__07_codemeta_object.py
@@ -28,6 +28,7 @@ class TestCodemetaObject(Contract):
                 "@type": "Organization",
                 "legalName": "Netherlands eScience Center"
             },
+            "alternateName": "jspaaks",
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
         }, {
@@ -44,7 +45,7 @@ class TestCodemetaObject(Contract):
                 "@type": "Organization",
                 "legalName": "MyAffiliation"
             },
-            "name": "mysteryauthor"
+            "alternateName": "mysteryauthor"
         }]
         assert codemeta_object.author == expected_author
 

--- a/test/1.1.0/07/test_1_1_0__07_schemaorg_object.py
+++ b/test/1.1.0/07/test_1_1_0__07_schemaorg_object.py
@@ -28,6 +28,7 @@ class TestSchemaorgObject(Contract):
                 "@type": "Organization",
                 "legalName": "Netherlands eScience Center"
             },
+            "alternateName": "jspaaks",
             "familyName": "Spaaks",
             "givenName": "Jurriaan H."
         }, {
@@ -44,7 +45,7 @@ class TestSchemaorgObject(Contract):
                 "@type": "Organization",
                 "legalName": "MyAffiliation"
             },
-            "name": "mysteryauthor"
+            "alternateName": "mysteryauthor"
         }]
         assert schemaorg_object.author == expected_author
 

--- a/test/1.2.0/authors-creators/one/GFA_AO/schemaorg.json
+++ b/test/1.2.0/authors-creators/one/GFA_AO/schemaorg.json
@@ -9,6 +9,7 @@
         "@type": "Organization",
         "legalName": "Netherlands eScience Center"
       },
+      "alternateName": "jspaaks",
       "familyName": "von der Spaaks Jr.",
       "givenName": "Jurriaan H."
     }

--- a/test/1.2.0/authors-creators/one/GFA_AO/test_1_2_0_authors_creators_one_GFA_AO_schemaorg_object.py
+++ b/test/1.2.0/authors-creators/one/GFA_AO/test_1_2_0_authors_creators_one_GFA_AO_schemaorg_object.py
@@ -29,6 +29,7 @@ class TestSchemaorgObject(Contract):
                 "@type": "Organization",
                 "legalName": "Netherlands eScience Center"
             },
+            "alternateName": "jspaaks",
             "familyName": "von der Spaaks Jr.",
             "givenName": "Jurriaan H."
         }]

--- a/test/1.2.0/authors-creators/one/GFA___/schemaorg.json
+++ b/test/1.2.0/authors-creators/one/GFA___/schemaorg.json
@@ -4,6 +4,7 @@
   "author": [
     {
       "@type": "Person",
+      "alternateName": "Rafa",
       "familyName": "van der Vaart III",
       "givenName": "Rafael"
     }

--- a/test/1.2.0/authors-creators/one/GFA___/test_1_2_0_authors_creators_one_GFA____schemaorg_object.py
+++ b/test/1.2.0/authors-creators/one/GFA___/test_1_2_0_authors_creators_one_GFA____schemaorg_object.py
@@ -24,6 +24,7 @@ class TestSchemaorgObject(Contract):
         schemaorg_object.add_author()
         expected_author = [{
             "@type": "Person",
+            "alternateName": "Rafa",
             "familyName": "van der Vaart III",
             "givenName": "Rafael"
         }]

--- a/test/1.2.0/authors-creators/one/G_A___/schemaorg.json
+++ b/test/1.2.0/authors-creators/one/G_A___/schemaorg.json
@@ -4,6 +4,7 @@
   "author": [
     {
       "@type": "Person",
+      "alternateName": "Rafa",
       "givenName": "Rafael"
     }
   ],

--- a/test/1.2.0/authors-creators/one/G_A___/test_1_2_0_authors_creators_one_G_A____schemaorg_object.py
+++ b/test/1.2.0/authors-creators/one/G_A___/test_1_2_0_authors_creators_one_G_A____schemaorg_object.py
@@ -24,6 +24,7 @@ class TestSchemaorgObject(Contract):
         schemaorg_object.add_author()
         expected_author = [{
             "@type": "Person",
+            "alternateName": "Rafa",
             "givenName": "Rafael"
         }]
         assert schemaorg_object.author == expected_author

--- a/test/1.2.0/authors-creators/one/_FA___/schemaorg.json
+++ b/test/1.2.0/authors-creators/one/_FA___/schemaorg.json
@@ -4,6 +4,7 @@
   "author": [
     {
       "@type": "Person",
+      "alternateName": "Rafa",
       "familyName": "van der Vaart III"
     }
   ],

--- a/test/1.2.0/authors-creators/one/_FA___/test_1_2_0_authors_creators_one__FA____schemaorg_object.py
+++ b/test/1.2.0/authors-creators/one/_FA___/test_1_2_0_authors_creators_one__FA____schemaorg_object.py
@@ -24,6 +24,7 @@ class TestSchemaorgObject(Contract):
         schemaorg_object.add_author()
         expected_author = [{
             "@type": "Person",
+            "alternateName": "Rafa",
             "familyName": "van der Vaart III"
         }]
         assert schemaorg_object.author == expected_author

--- a/test/1.2.0/authors-creators/one/__AN__/schemaorg.json
+++ b/test/1.2.0/authors-creators/one/__AN__/schemaorg.json
@@ -4,7 +4,8 @@
   "author": [
     {
       "@type": "Person",
-      "name": "Rafa"
+      "alternateName": "Rafa",
+      "name": "The soccer team members"
     }
   ],
   "name": "the title"

--- a/test/1.2.0/authors-creators/one/__AN__/test_1_2_0_authors_creators_one___AN___schemaorg_object.py
+++ b/test/1.2.0/authors-creators/one/__AN__/test_1_2_0_authors_creators_one___AN___schemaorg_object.py
@@ -24,7 +24,8 @@ class TestSchemaorgObject(Contract):
         schemaorg_object.add_author()
         expected_author = [{
             "@type": "Person",
-            "name": "Rafa"
+            "alternateName": "Rafa",
+            "name": "The soccer team members"
         }]
         assert schemaorg_object.author == expected_author
 

--- a/test/1.2.0/authors-creators/two/GFA___/schemaorg.json
+++ b/test/1.2.0/authors-creators/two/GFA___/schemaorg.json
@@ -4,11 +4,13 @@
   "author": [
     {
       "@type": "Person",
+      "alternateName": "Rafa",
       "familyName": "van der Vaart III",
       "givenName": "Rafael"
     },
     {
       "@type": "Person",
+      "alternateName": "Ronaldo",
       "familyName": "dos Santos Aveiro",
       "givenName": "Cristiano Ronaldo"
     }

--- a/test/1.2.0/authors-creators/two/GFA___/test_1_2_0_authors_creators_two_GFA____schemaorg_object.py
+++ b/test/1.2.0/authors-creators/two/GFA___/test_1_2_0_authors_creators_two_GFA____schemaorg_object.py
@@ -24,10 +24,12 @@ class TestSchemaorgObject(Contract):
         schemaorg_object.add_author()
         expected_author = [{
             "@type": "Person",
+            "alternateName": "Rafa",
             "familyName": "van der Vaart III",
             "givenName": "Rafael"
         }, {
             "@type": "Person",
+            "alternateName": "Ronaldo",
             "familyName": "dos Santos Aveiro",
             "givenName": "Cristiano Ronaldo"
         }]

--- a/test/1.2.0/authors-creators/two/G_A___/schemaorg.json
+++ b/test/1.2.0/authors-creators/two/G_A___/schemaorg.json
@@ -4,10 +4,12 @@
   "author": [
     {
       "@type": "Person",
+      "alternateName": "Rafa",
       "givenName": "Rafael"
     },
     {
       "@type": "Person",
+      "alternateName": "Ronaldo",
       "givenName": "Cristiano Ronaldo"
     }
   ],

--- a/test/1.2.0/authors-creators/two/G_A___/test_1_2_0_authors_creators_two_G_A____schemaorg_object.py
+++ b/test/1.2.0/authors-creators/two/G_A___/test_1_2_0_authors_creators_two_G_A____schemaorg_object.py
@@ -24,9 +24,11 @@ class TestSchemaorgObject(Contract):
         schemaorg_object.add_author()
         expected_author = [{
             "@type": "Person",
+            "alternateName": "Rafa",
             "givenName": "Rafael"
         }, {
             "@type": "Person",
+            "alternateName": "Ronaldo",
             "givenName": "Cristiano Ronaldo"
         }]
         assert schemaorg_object.author == expected_author

--- a/test/1.2.0/authors-creators/two/_FA___/schemaorg.json
+++ b/test/1.2.0/authors-creators/two/_FA___/schemaorg.json
@@ -4,10 +4,12 @@
   "author": [
     {
       "@type": "Person",
+      "alternateName": "Rafa",
       "familyName": "van der Vaart III"
     },
     {
       "@type": "Person",
+      "alternateName": "Ronaldo",
       "familyName": "dos Santos Aveiro"
     }
   ],

--- a/test/1.2.0/authors-creators/two/_FA___/test_1_2_0_authors_creators_two__FA____schemaorg_object.py
+++ b/test/1.2.0/authors-creators/two/_FA___/test_1_2_0_authors_creators_two__FA____schemaorg_object.py
@@ -24,9 +24,11 @@ class TestSchemaorgObject(Contract):
         schemaorg_object.add_author()
         expected_author = [{
             "@type": "Person",
+            "alternateName": "Rafa",
             "familyName": "van der Vaart III"
         }, {
             "@type": "Person",
+            "alternateName": "Ronaldo",
             "familyName": "dos Santos Aveiro"
         }]
         assert schemaorg_object.author == expected_author

--- a/test/1.2.0/authors-creators/two/__AN__/schemaorg.json
+++ b/test/1.2.0/authors-creators/two/__AN__/schemaorg.json
@@ -4,11 +4,13 @@
   "author": [
     {
       "@type": "Person",
-      "name": "Rafa"
+      "alternateName": "Rafa",
+      "name": "The soccer team members"
     },
     {
       "@type": "Person",
-      "name": "coach"
+      "alternateName": "coach",
+      "name": "The trainers"
     }
   ],
   "name": "the title"

--- a/test/1.2.0/authors-creators/two/__AN__/test_1_2_0_authors_creators_two___AN___schemaorg_object.py
+++ b/test/1.2.0/authors-creators/two/__AN__/test_1_2_0_authors_creators_two___AN___schemaorg_object.py
@@ -24,10 +24,12 @@ class TestSchemaorgObject(Contract):
         schemaorg_object.add_author()
         expected_author = [{
             "@type": "Person",
-            "name": "Rafa"
+            "alternateName": "Rafa",
+            "name": "The soccer team members"
         }, {
             "@type": "Person",
-            "name": "coach"
+            "alternateName": "coach",
+            "name": "The trainers"
         }]
         assert schemaorg_object.author == expected_author
 


### PR DESCRIPTION
Schemaorg and codemeta exports can now additionally use `alias` and/or `name` (mapped to `alternateName` and `name`, respectively).