### PR TITLE
version string consistency checks

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -39,5 +39,6 @@
   "license": {
     "id": "Apache-2.0"
   },
-  "title": "cffconvert"
+  "title": "cffconvert",
+  "version": "2.0.0-alpha.0"
 }

--- a/README.dev.md
+++ b/README.dev.md
@@ -38,9 +38,6 @@ bash test/test_consistent_file_naming.sh dir=livetest/
 
 # tests for consistent versioning
 python3 -m pytest test/test_consistent_versioning.py
-
-# run tests against live system (GitHub)
-python3 -m pytest livetest
 ```
 
 ## Running linters locally
@@ -113,8 +110,8 @@ git config --local core.hooksPath .githooks
     # make a source distribution:
     python setup.py sdist
     # install the 'upload to pypi/testpypi tool' aka twine
-    pip install twine
-    # upload the contents of the source distribtion we just made
+    pip install .[publishing]
+    # upload the contents of the source distribution we just made
     twine upload --repository-url https://test.pypi.org/legacy/ dist/*
 
     # checking the package
@@ -127,3 +124,23 @@ git config --local core.hooksPath .githooks
     # FINAL STEP: upload to PyPI
     twine upload dist/*
     ```
+
+### Building the docker image
+
+```shell
+# (requires 2.0.0-alpha.0 to be downloadable from PyPI)
+docker build --tag cffconvert:2.0.0-alpha.0 .
+docker build --tag cffconvert:latest .
+```
+
+### Publishing on DockerHub
+
+See <https://docs.docker.com/docker-hub/repos/#pushing-a-docker-container-image-to-docker-hub> for more information on publishing.
+
+```shell
+# re-tag existing image
+docker tag cffconvert:2.0.0-alpha.0 citationcff/cffconvert:2.0.0-alpha.0
+
+# publish
+docker push citationcff/cffconvert:2.0.0-alpha.0
+```

--- a/setup.cfg
+++ b/setup.cfg
@@ -64,7 +64,6 @@ console_scripts =
 
 [options.extras_require]
 dev =
-    bump2version
     prospector[with_pyroma] >= 1.4
     isort
     pytest >=6

--- a/test/1.0.3/01/test_1_0_3__01_cli.py
+++ b/test/1.0.3/01/test_1_0_3__01_cli.py
@@ -31,7 +31,7 @@ def test_printing_of_version():
     with runner.isolated_filesystem():
         result = runner.invoke(cffconvert_cli, ["--version"])
     assert result.exit_code == 0
-    assert result.output, "2.0.0-alpha.0\n"
+    assert result.output == "2.0.0-alpha.0\n"
 
 
 def test_printing_on_stdout_as_bibtex():

--- a/test/test_consistent_versioning.py
+++ b/test/test_consistent_versioning.py
@@ -89,7 +89,8 @@ def test_readme_dev_md_3():
     fixture = os.path.join(get_package_root(), "..", "README.dev.md")
     with open(fixture, "rt", encoding="utf-8") as fid:
         file_contents = fid.read()
-    regex = re.compile(r'^docker tag cffconvert:(?P<version1>\S*) citationcff/cffconvert:(?P<version2>\S*)$', re.MULTILINE)
+    regex = re.compile(r'^docker tag cffconvert:(?P<version1>\S*) citationcff/' +
+                       r'cffconvert:(?P<version2>\S*)$', re.MULTILINE)
     actual_version_1 = re.search(regex, file_contents)['version1']
     actual_version_2 = re.search(regex, file_contents)['version2']
     assert actual_version_1 == expected_version

--- a/test/test_consistent_versioning.py
+++ b/test/test_consistent_versioning.py
@@ -67,6 +67,16 @@ def test_test_1_1_0__01_cli_py():
     assert actual_version == expected_version
 
 
+def test_1_2_0_doi_identifiers_d__cli_py():
+    fixture = os.path.join(get_package_root(), "..", "test", "1.2.0", "doi-identifiers", "D_",
+                           "test_1_2_0_doi_identifiers_D__cli.py")
+    with open(fixture, "rt", encoding="utf-8") as fid:
+        file_contents = fid.read()
+    regex = re.compile(r'^[ ]{4}assert result\.output == "(?P<version>\S*)\\n"$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version
+
+
 def test_readme_dev_md_1():
     fixture = os.path.join(get_package_root(), "..", "README.dev.md")
     with open(fixture, "rt", encoding="utf-8") as fid:

--- a/test/test_consistent_versioning.py
+++ b/test/test_consistent_versioning.py
@@ -1,39 +1,105 @@
 import json
 import os
+import re
 from ruamel.yaml import YAML
 from cffconvert.version import __version__ as expected_version
+from cffconvert.root import get_package_root
 
 
-def test_version_number_cff():
-    # CITATION.cff content should have the same semver as setup.cfg / version.py
-    fixture = os.path.join("CITATION.cff")
+def test_citation_cff():
+    fixture = os.path.join(get_package_root(), "..", "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as fid:
-        cff_contents = fid.read()
-    actual_version = YAML(typ='safe').load(cff_contents)["version"]
-    assert expected_version == actual_version
+        file_contents = fid.read()
+    actual_version = YAML(typ='safe').load(file_contents)["version"]
+    assert actual_version == expected_version
 
 
-def test_zenodo_has_no_version_number():
-    # .zenodo.json content should not have any semver information, Zenodo retrieves this automatically from the
-    # Zenodo-GitHub integration
-    fixture = os.path.join(".zenodo.json")
+def test_zenodo_json():
+    fixture = os.path.join(get_package_root(), "..", ".zenodo.json")
     with open(fixture, "rt", encoding="utf-8") as fid:
-        zenodojson_contents = fid.read()
-    assert "version" not in json.loads(zenodojson_contents).keys()
+        file_contents = fid.read()
+    actual_version = json.loads(file_contents)["version"]
+    assert actual_version == expected_version
 
 
-def test_zenodo_has_no_doi():
-    # .zenodo.json content should not have any doi information since you cannot tell Zenodo what the doi should be
-    fixture = os.path.join(".zenodo.json")
+def test_dockerfile():
+    fixture = os.path.join(get_package_root(), "..", "Dockerfile")
     with open(fixture, "rt", encoding="utf-8") as fid:
-        zenodojson_contents = fid.read()
-    assert "doi" not in json.loads(zenodojson_contents).keys()
+        file_contents = fid.read()
+    regex = re.compile(r'^RUN .* cffconvert==(?P<version>\S*)$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version
 
 
-def test_zenodo_has_no_date_published():
-    # .zenodo.json content should not have any date information, the Zenodo-GitHub integration assigns
-    # the date as today's date
-    fixture = os.path.join(".zenodo.json")
+def test_setup_cfg():
+    fixture = os.path.join(get_package_root(), "..", "setup.cfg")
     with open(fixture, "rt", encoding="utf-8") as fid:
-        zenodojson_contents = fid.read()
-    assert "publication_date" not in json.loads(zenodojson_contents).keys()
+        file_contents = fid.read()
+    regex = re.compile(r'^version = (?P<version>\S*)$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version
+
+
+def test_alternative_install_options_md():
+    fixture = os.path.join(get_package_root(), "..", "docs", "alternative-install-options.md")
+    with open(fixture, "rt", encoding="utf-8") as fid:
+        file_contents = fid.read()
+    regex = re.compile(r'^docker build --tag cffconvert:(?P<version>\S*) .$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version
+
+
+def test_test_1_0_3__01_cli_py():
+    fixture = os.path.join(get_package_root(), "..", "test", "1.0.3", "01", "test_1_0_3__01_cli.py")
+    with open(fixture, "rt", encoding="utf-8") as fid:
+        file_contents = fid.read()
+    regex = re.compile(r'^[ ]{4}assert result\.output == "(?P<version>\S*)\\n"$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version
+
+
+def test_test_1_1_0__01_cli_py():
+    fixture = os.path.join(get_package_root(), "..", "test", "1.1.0", "01", "test_1_1_0__01_cli.py")
+    with open(fixture, "rt", encoding="utf-8") as fid:
+        file_contents = fid.read()
+    regex = re.compile(r'^[ ]{4}assert result\.output == "(?P<version>\S*)\\n"$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version
+
+
+def test_readme_dev_md_1():
+    fixture = os.path.join(get_package_root(), "..", "README.dev.md")
+    with open(fixture, "rt", encoding="utf-8") as fid:
+        file_contents = fid.read()
+    regex = re.compile(r'^# \(requires (?P<version>\S*) to be downloadable from PyPI\)$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version
+
+
+def test_readme_dev_md_2():
+    fixture = os.path.join(get_package_root(), "..", "README.dev.md")
+    with open(fixture, "rt", encoding="utf-8") as fid:
+        file_contents = fid.read()
+    regex = re.compile(r'^docker build --tag cffconvert:(?P<version>\S*) .$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version
+
+
+def test_readme_dev_md_3():
+    fixture = os.path.join(get_package_root(), "..", "README.dev.md")
+    with open(fixture, "rt", encoding="utf-8") as fid:
+        file_contents = fid.read()
+    regex = re.compile(r'^docker tag cffconvert:(?P<version1>\S*) citationcff/cffconvert:(?P<version2>\S*)$', re.MULTILINE)
+    actual_version_1 = re.search(regex, file_contents)['version1']
+    actual_version_2 = re.search(regex, file_contents)['version2']
+    assert actual_version_1 == expected_version
+    assert actual_version_2 == expected_version
+
+
+def test_readme_dev_md_4():
+    fixture = os.path.join(get_package_root(), "..", "README.dev.md")
+    with open(fixture, "rt", encoding="utf-8") as fid:
+        file_contents = fid.read()
+    regex = re.compile(r'^docker push citationcff/cffconvert:(?P<version>\S*)$', re.MULTILINE)
+    actual_version = re.search(regex, file_contents)['version']
+    assert actual_version == expected_version


### PR DESCRIPTION
Instead of bumpversion, I'm now using a unit test that tests for consistency with `cffconvert/version::__version__`

Refs: #211, #188