### PR TITLE
rawifying urls

### DIFF
--- a/cffconvert/cli/rawify_github_link.py
+++ b/cffconvert/cli/rawify_github_link.py
@@ -1,6 +1,0 @@
-def rawify_github_link(url):
-    # just a placeholder replacement for the moment
-    if url == "https://github.com/citation-file-format/cff-converter-python":
-        return "https://raw.githubusercontent.com/citation-file-format/cff-converter-python/main/CITATION.cff"
-    # return unrecognized URLs as-is
-    return url

--- a/cffconvert/cli/rawify_url.py
+++ b/cffconvert/cli/rawify_url.py
@@ -2,7 +2,8 @@ def rawify_url(url):
     github_base_url = "https://github.com"
     if url.startswith(github_base_url):
         n = len("https://github.com") + 1
-        ownername, reponame, reftype, refvalue, filename = (url[n:].split('/') + [None] * 3)[:5]
+        urlparts = (url[n:].rstrip('/').split('/') + [None] * 3)[:5]
+        ownername, reponame, reftype, refvalue, filename = urlparts
         if refvalue is None:
             refvalue = "main"
         if filename is None:

--- a/cffconvert/cli/rawify_url.py
+++ b/cffconvert/cli/rawify_url.py
@@ -1,0 +1,13 @@
+def rawify_url(url):
+    github_base_url = "https://github.com"
+    if url.startswith(github_base_url):
+        n = len("https://github.com") + 1
+        ownername, reponame, reftype, refvalue, filename = (url[n:].split('/') + [None] * 3)[:5]
+        if refvalue is None:
+            refvalue = "main"
+        if filename is None:
+            filename = "CITATION.cff"
+        return "https://raw.githubusercontent.com/{0}/{1}/{2}/{3}".format(ownername, reponame, refvalue, filename)
+
+    # return unrecognized URLs as-is
+    return url

--- a/cffconvert/cli/read_from_url.py
+++ b/cffconvert/cli/read_from_url.py
@@ -1,14 +1,14 @@
 import requests
-from cffconvert.cli.rawify_github_link import rawify_github_link
+from cffconvert.cli.rawify_url import rawify_url as rawify
 
 
 def read_from_url(url):
     if not url.startswith("https://"):
         raise AssertionError("URL should be an https:// link")
 
-    url_fetch = rawify_github_link(url)
+    url_raw = rawify(url)
 
-    r = requests.get(url_fetch)
+    r = requests.get(url_raw)
     if r.ok:
         return r.text
-    raise Exception("Error while trying to retrieve {0}".format(url_fetch))
+    raise Exception("Error while trying to retrieve {0}".format(url_raw))

--- a/test/test_rawify_url.py
+++ b/test/test_rawify_url.py
@@ -1,0 +1,91 @@
+from cffconvert.cli.rawify_url import rawify_url
+
+
+def test_github_url_with_owner_repo():
+    actual = rawify_url("https://github.com/theownername/thereponame")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/main/CITATION.cff"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_blob_branchname():
+    actual = rawify_url("https://github.com/theownername/thereponame/blob/thebranchname")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/thebranchname/CITATION.cff"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_blob_branchname_filename():
+    actual = rawify_url("https://github.com/theownername/thereponame/blob/thebranchname/thefilename")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/thebranchname/thefilename"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_blob_sha():
+    actual = rawify_url("https://github.com/theownername/thereponame/blob/0123456789abcdef0123456789abcdef01234567")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/CITATION.cff"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_blob_sha_filename():
+    actual = rawify_url("https://github.com/theownername/thereponame/blob/0123456789abcdef0123456789abcdef01234567/thefilename")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/thefilename"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_blob_tagname():
+    actual = rawify_url("https://github.com/theownername/thereponame/blob/1.0.0")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/1.0.0/CITATION.cff"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_blob_tagname_filename():
+    actual = rawify_url("https://github.com/theownername/thereponame/blob/1.0.0/thefilename")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/1.0.0/thefilename"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_commit_sha():
+    actual = rawify_url("https://github.com/theownername/thereponame/commit/0123456789abcdef0123456789abcdef01234567")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/CITATION.cff"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_commit_sha_filename():
+    actual = rawify_url("https://github.com/theownername/thereponame/commit/0123456789abcdef0123456789abcdef01234567/thefilename")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/thefilename"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_tree_branchname():
+    actual = rawify_url("https://github.com/theownername/thereponame/tree/thebranchname")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/thebranchname/CITATION.cff"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_tree_branchname_filename():
+    actual = rawify_url("https://github.com/theownername/thereponame/tree/thebranchname/thefilename")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/thebranchname/thefilename"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_tree_sha():
+    actual = rawify_url("https://github.com/theownername/thereponame/tree/0123456789abcdef0123456789abcdef01234567")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/CITATION.cff"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_tree_sha_filename():
+    actual = rawify_url("https://github.com/theownername/thereponame/tree/0123456789abcdef0123456789abcdef01234567/thefilename")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/thefilename"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_tree_tagname():
+    actual = rawify_url("https://github.com/theownername/thereponame/tree/1.0.0")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/1.0.0/CITATION.cff"
+    assert actual == expected
+
+
+def test_github_url_with_owner_repo_tree_tagname_filename():
+    actual = rawify_url("https://github.com/theownername/thereponame/tree/1.0.0/thefilename")
+    expected = "https://raw.githubusercontent.com/theownername/thereponame/1.0.0/thefilename"
+    assert actual == expected


### PR DESCRIPTION
This PR adds rawification of github urls, e.g. cli argument `--url https://github.com/ownername/reponame` will now try to retrieve `https://raw.githubusercontent.com/ownername/reponame/CITATION.cff`.