### PR TITLE
Provide pre-commit hook

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,6 +1,6 @@
-- id: cffconvert
-  name: cffconvert
-  description: Validate and convert CITATION.cff files
+- id: validate-cff
+  name: Validate CITATION.cff files
+  description: Runs `cffconvert --validate` on `.cff` files.
   entry: cffconvert --validate -i
   language: python
   files: \.cff$

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,8 +1,9 @@
 - id: validate-cff
-  name: Validate CITATION.cff files
-  description: Runs `cffconvert --validate` on `.cff` files.
-  entry: cffconvert --validate -i
+  name: Validate repo CITATION.cff file
+  description: Runs `cffconvert --validate`.
+  entry: cffconvert --validate
   language: python
-  files: \.cff$
+  files: ^CITATION.cff$
+  pass_filenames: false
   types: [text]
   require_serial: true

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,8 @@
+- id: cffconvert
+  name: cffconvert
+  description: Validate and convert CITATION.cff files
+  entry: cffconvert --validate -i
+  language: python
+  files: \.cff$
+  types: [text]
+  require_serial: true


### PR DESCRIPTION
Closes #268 

This seems to work fine. The issue is that if the validation doesn't pass, some errors cause the whole schema to be printed, which takes a lot of lines, so you have to scroll far up to find the actual helpful message.