### PR TITLE
Automatic validation of your citation metadata

### DIFF
--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -1,0 +1,19 @@
+name: cffconvert
+
+on:
+  push:
+    paths:
+      - CITATION.cff
+
+jobs:
+  validate:
+    name: "validate"
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out a copy of the repository
+        uses: actions/checkout@v2
+
+      - name: Check whether the citation metadata from CITATION.cff is valid
+        uses: citation-file-format/cffconvert-github-action@2.0.0
+        with:
+          args: "--validate"

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - CITATION.cff
-  workflow_dispatch
+  workflow_dispatch:
 jobs:
   validate:
     name: "validate"

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -5,6 +5,7 @@ on:
     paths:
       - CITATION.cff
   workflow_dispatch:
+
 jobs:
   validate:
     name: "validate"

--- a/.github/workflows/cffconvert.yml
+++ b/.github/workflows/cffconvert.yml
@@ -4,7 +4,7 @@ on:
   push:
     paths:
       - CITATION.cff
-
+  workflow_dispatch
 jobs:
   validate:
     name: "validate"


### PR DESCRIPTION
Hello!

We noticed that your repository is using the Citation File Format to store citation metadata in `CITATION.cff`. This Pull Request automates validation of that file using the [cffconvert GitHub Action](https://github.com/marketplace/actions/cffconvert). That way, it's a little bit easier to be robust against future changes to the `CITATION.cff` file.

BTW it's perfectly fine if you don't feel like accepting this Pull Request for whatever reason -- we just thought it might be helpful is all.

We found your repository using a partially automated workflow; if you have any questions about that, feel free to create an issue over at https://github.com/cffbots/filtering/issues/

On behalf of the cffbots team,
@abelsiqueira / @fdiblen / @jspaaks