### PR TITLE
Allow jsonschema 4.x

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -52,7 +52,7 @@ install_requires =
     requests >=2.20, <3
     ruamel.yaml >=0.16.0
     pykwalify >=1.6
-    jsonschema >=3.0, <4
+    jsonschema >=3.0, <5
 
 [options.data_files]
 # This section requires setuptools>=40.6.0


### PR DESCRIPTION
I tested with `jsonschema` 4.6.0 and found that all the tests in `test/` and `livetest/` still pass.