### PR TITLE
Enabled verbosity control from cli

### DIFF
--- a/cffconvert/behavior_1_0_x/citation.py
+++ b/cffconvert/behavior_1_0_x/citation.py
@@ -62,6 +62,6 @@ class Citation_1_0_x(Contract):  # nopep8
     def as_zenodo(self):
         return ZenodoObject(self.cffobj).as_string()
 
-    def validate(self):
+    def validate(self, verbose=True):
         # validation using YAML based schema
         Core(source_data=self.cffobj, schema_data=self.schema).validate(raise_exception=True)

--- a/cffconvert/behavior_1_1_x/citation.py
+++ b/cffconvert/behavior_1_1_x/citation.py
@@ -60,6 +60,6 @@ class Citation_1_1_x(Contract):  # nopep8
     def as_zenodo(self):
         return ZenodoObject(self.cffobj).as_string()
 
-    def validate(self):
+    def validate(self, verbose=True):
         # validation using YAML based schema
         Core(source_data=self.cffobj, schema_data=self.schema).validate(raise_exception=True)

--- a/cffconvert/behavior_1_2_x/citation.py
+++ b/cffconvert/behavior_1_2_x/citation.py
@@ -1,6 +1,7 @@
 import json
 import os
 import jsonschema
+from jsonschema.exceptions import ValidationError
 from ruamel.yaml import YAML
 from cffconvert.behavior_1_2_x.apalike_object import ApalikeObject
 from cffconvert.behavior_1_2_x.bibtex_object import BibtexObject
@@ -70,5 +71,19 @@ class Citation_1_2_x(Contract):  # nopep8
     def as_zenodo(self):
         return ZenodoObject(self.cffobj).as_string()
 
-    def validate(self):
-        jsonschema.validate(instance=self.cffobj, schema=self.schema, format_checker=jsonschema.FormatChecker())
+    def validate(self, verbose=True):
+        try:
+            jsonschema.validate(instance=self.cffobj, schema=self.schema, format_checker=jsonschema.FormatChecker())
+        except ValidationError as error:
+            error_lines = str(error).splitlines()
+            is_long = len(error_lines) > 25
+
+            if is_long and not verbose:
+                truncated_message = "\n".join(
+                        [ *error_lines[0:25], "", "...truncated output...", "Add --verbose flag for full output."]
+                        )
+                raise ValidationError(truncated_message)
+            raise
+
+
+            

--- a/cffconvert/cli/cli.py
+++ b/cffconvert/cli/cli.py
@@ -58,6 +58,11 @@ options = {
         is_flag=True,
         default=False,
         help="Print version and exit."
+    ),
+    "verbose": dict(
+        is_flag=True,
+        default=False,
+        help="Control output verbosity."
     )
 }
 
@@ -71,8 +76,9 @@ options = {
 @click.option("--show-trace", "show_trace", **options["show_trace"])
 @click.option("--validate", "validate_only", **options["validate_only"])
 @click.option("--version", "version", **options["version"])
+@click.option("--verbose", "verbose", **options["verbose"])
 # pylint: disable=too-many-arguments
-def cli(infile, outfile, outputformat, url, show_help, show_trace, validate_only, version):
+def cli(infile, outfile, outputformat, url, show_help, show_trace, validate_only, version, verbose):
 
     check_early_exits(show_help, version)
 
@@ -88,4 +94,4 @@ def cli(infile, outfile, outputformat, url, show_help, show_trace, validate_only
     citation = create_citation(infile, url)
 
     # either validate and exit, or convert to the selected output format
-    validate_or_write_output(outfile, outputformat, validate_only, citation)
+    validate_or_write_output(outfile, outputformat, validate_only, citation, verbose)

--- a/cffconvert/cli/validate_or_write_output.py
+++ b/cffconvert/cli/validate_or_write_output.py
@@ -3,15 +3,15 @@ from jsonschema.exceptions import ValidationError as JsonschemaSchemaError
 from pykwalify.errors import SchemaError as PykwalifySchemaError
 
 
-def validate_or_write_output(outfile, outputformat, validate_only, citation):
+def validate_or_write_output(outfile, outputformat, validate_only, citation, verbose=True):
     condition = (validate_only, outputformat is not None)
     if condition == (True, False):
         # just validate, there is no target outputformat
-        citation.validate()
+        citation.validate(verbose)
         print(f"Citation metadata are valid according to schema version {citation.cffversion}.")
     elif condition == (True, True):
         # just validate, ignore the target outputformat
-        citation.validate()
+        citation.validate(verbose)
         print(f"Ignoring output format. Citation metadata are valid according to schema version {citation.cffversion}.")
     elif condition == (False, False):
         # user hasn't indicated what they want
@@ -19,7 +19,7 @@ def validate_or_write_output(outfile, outputformat, validate_only, citation):
     elif condition == (False, True):
         # validate the input, then write to target outputformat
         try:
-            citation.validate()
+            citation.validate(verbose)
         except (PykwalifySchemaError, JsonschemaSchemaError):
             print(f"'{citation.src}' does not pass validation. Conversion aborted.")
             ctx = click.get_current_context()


### PR DESCRIPTION
Made a quick pull request for controlling the output of the validation errors (#278) when validating a `CITATION.cff` file through the command-line i.e., `cffconvert --validate`. 

Testing this should be easy enough but the `./test` folder is quite expansive and did not find a simple place to put tests for this functionality. Hopefully this is helpful! Just wanted to quickly implement a draft of the simple fix for the issue.

Something like this should be in my opinion implemented before letting people use the `pre-commit` hook implemented on the default branch (#284).

Let me know about things to change/fix/add!