### PR TITLE
No creative work, default to software

### DIFF
--- a/cffconvert/behavior_1_2_x/schemaorg_object.py
+++ b/cffconvert/behavior_1_2_x/schemaorg_object.py
@@ -85,7 +85,8 @@ class SchemaorgObject(Shared):
         elif typ == "software":
             self.type = "SoftwareSourceCode"
         else:
-            self.type = "CreativeWork"
+            # default value for 'type' is 'software'
+            self.type = "SoftwareSourceCode"
         return self
 
     def add_urls(self):

--- a/cffconvert/behavior_1_2_x/schemaorg_object.py
+++ b/cffconvert/behavior_1_2_x/schemaorg_object.py
@@ -90,4 +90,8 @@ class SchemaorgObject(Shared):
 
     def add_urls(self):
         self.code_repository, self.url = SchemaorgUrls(self.cffobj).as_tuple()
+        # schema.org does not specify a target conversion key for
+        # repository-code when type == 'dataset', so remove it
+        if self.cffobj.get("type", "") == "dataset":
+            self.code_repository = None
         return self

--- a/cffconvert/behavior_1_2_x/zenodo_object.py
+++ b/cffconvert/behavior_1_2_x/zenodo_object.py
@@ -59,9 +59,12 @@ class ZenodoObject(Shared):
         return self
 
     def add_upload_type(self):
-        if "type" in self.cffobj.keys():
-            if self.cffobj["type"] == "software":
-                self.upload_type = "software"
-            if self.cffobj["type"] == "dataset":
-                self.upload_type = "dataset"
+        typ = self.cffobj.get("type", "")
+        if typ == "dataset":
+            self.upload_type = "dataset"
+        elif typ == "software":
+            self.upload_type = "software"
+        else:
+            # default value for type is 'software'
+            self.upload_type = "software"
         return self

--- a/test/1.2.0/authors/one/GFA_AO/.zenodo.json
+++ b/test/1.2.0/authors/one/GFA_AO/.zenodo.json
@@ -6,5 +6,6 @@
       "orcid": "0000-0002-7064-4069"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/GFA_AO/schemaorg.json
+++ b/test/1.2.0/authors/one/GFA_AO/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@id": "https://orcid.org/0000-0002-7064-4069",

--- a/test/1.2.0/authors/one/GFA_AO/test_1_2_0_authors_creators_one_GFA_AO_schemaorg_object.py
+++ b/test/1.2.0/authors/one/GFA_AO/test_1_2_0_authors_creators_one_GFA_AO_schemaorg_object.py
@@ -57,6 +57,9 @@ class TestSchemaorgObject(Contract):
     def test_version(self, schemaorg_object):
         assert schemaorg_object.add_version().version is None
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/GFA_AO/test_1_2_0_authors_creators_one_GFA_AO_zenodo_object.py
+++ b/test/1.2.0/authors/one/GFA_AO/test_1_2_0_authors_creators_one_GFA_AO_zenodo_object.py
@@ -48,5 +48,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/one/GFA___/.zenodo.json
+++ b/test/1.2.0/authors/one/GFA___/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "van der Vaart III, Rafael"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/GFA___/schemaorg.json
+++ b/test/1.2.0/authors/one/GFA___/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/one/GFA___/test_1_2_0_authors_creators_one_GFA____schemaorg_object.py
+++ b/test/1.2.0/authors/one/GFA___/test_1_2_0_authors_creators_one_GFA____schemaorg_object.py
@@ -56,6 +56,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/GFA___/test_1_2_0_authors_creators_one_GFA____zenodo_object.py
+++ b/test/1.2.0/authors/one/GFA___/test_1_2_0_authors_creators_one_GFA____zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/one/GF____/.zenodo.json
+++ b/test/1.2.0/authors/one/GF____/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "van der Vaart III, Rafael"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/GF____/schemaorg.json
+++ b/test/1.2.0/authors/one/GF____/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/one/GF____/test_1_2_0_authors_creators_one_GF_____schemaorg_object.py
+++ b/test/1.2.0/authors/one/GF____/test_1_2_0_authors_creators_one_GF_____schemaorg_object.py
@@ -55,6 +55,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/GF____/test_1_2_0_authors_creators_one_GF_____zenodo_object.py
+++ b/test/1.2.0/authors/one/GF____/test_1_2_0_authors_creators_one_GF_____zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/one/G_A___/.zenodo.json
+++ b/test/1.2.0/authors/one/G_A___/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Rafael"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/G_A___/schemaorg.json
+++ b/test/1.2.0/authors/one/G_A___/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/one/G_A___/test_1_2_0_authors_creators_one_G_A____schemaorg_object.py
+++ b/test/1.2.0/authors/one/G_A___/test_1_2_0_authors_creators_one_G_A____schemaorg_object.py
@@ -55,6 +55,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/G_A___/test_1_2_0_authors_creators_one_G_A____zenodo_object.py
+++ b/test/1.2.0/authors/one/G_A___/test_1_2_0_authors_creators_one_G_A____zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/one/G_____/.zenodo.json
+++ b/test/1.2.0/authors/one/G_____/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Rafael"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/G_____/schemaorg.json
+++ b/test/1.2.0/authors/one/G_____/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/one/G_____/test_1_2_0_authors_creators_one_G______schemaorg_object.py
+++ b/test/1.2.0/authors/one/G_____/test_1_2_0_authors_creators_one_G______schemaorg_object.py
@@ -54,6 +54,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/G_____/test_1_2_0_authors_creators_one_G______zenodo_object.py
+++ b/test/1.2.0/authors/one/G_____/test_1_2_0_authors_creators_one_G______zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/one/_FA___/.zenodo.json
+++ b/test/1.2.0/authors/one/_FA___/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "van der Vaart III"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/_FA___/schemaorg.json
+++ b/test/1.2.0/authors/one/_FA___/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/one/_FA___/test_1_2_0_authors_creators_one__FA____schemaorg_object.py
+++ b/test/1.2.0/authors/one/_FA___/test_1_2_0_authors_creators_one__FA____schemaorg_object.py
@@ -55,6 +55,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/_FA___/test_1_2_0_authors_creators_one__FA____zenodo_object.py
+++ b/test/1.2.0/authors/one/_FA___/test_1_2_0_authors_creators_one__FA____zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/one/_F____/.zenodo.json
+++ b/test/1.2.0/authors/one/_F____/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "van der Vaart III"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/_F____/schemaorg.json
+++ b/test/1.2.0/authors/one/_F____/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/one/_F____/test_1_2_0_authors_creators_one__F_____schemaorg_object.py
+++ b/test/1.2.0/authors/one/_F____/test_1_2_0_authors_creators_one__F_____schemaorg_object.py
@@ -54,6 +54,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/_F____/test_1_2_0_authors_creators_one__F_____zenodo_object.py
+++ b/test/1.2.0/authors/one/_F____/test_1_2_0_authors_creators_one__F_____zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/one/__AN__/.zenodo.json
+++ b/test/1.2.0/authors/one/__AN__/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Rafa"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/__AN__/schemaorg.json
+++ b/test/1.2.0/authors/one/__AN__/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/one/__AN__/test_1_2_0_authors_creators_one___AN___schemaorg_object.py
+++ b/test/1.2.0/authors/one/__AN__/test_1_2_0_authors_creators_one___AN___schemaorg_object.py
@@ -55,6 +55,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/__AN__/test_1_2_0_authors_creators_one___AN___zenodo_object.py
+++ b/test/1.2.0/authors/one/__AN__/test_1_2_0_authors_creators_one___AN___zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/one/___N__/.zenodo.json
+++ b/test/1.2.0/authors/one/___N__/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "The soccer team members"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/one/___N__/schemaorg.json
+++ b/test/1.2.0/authors/one/___N__/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/one/___N__/test_1_2_0_authors_creators_one____N___schemaorg_object.py
+++ b/test/1.2.0/authors/one/___N__/test_1_2_0_authors_creators_one____N___schemaorg_object.py
@@ -54,6 +54,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/one/___N__/test_1_2_0_authors_creators_one____N___zenodo_object.py
+++ b/test/1.2.0/authors/one/___N__/test_1_2_0_authors_creators_one____N___zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/authors/two/GF____/.zenodo.json
+++ b/test/1.2.0/authors/two/GF____/.zenodo.json
@@ -7,5 +7,6 @@
       "name": "dos Santos Aveiro, Cristiano Ronaldo"
     }
   ],
-  "title": "the title"
+  "title": "the title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/authors/two/GF____/schemaorg.json
+++ b/test/1.2.0/authors/two/GF____/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/authors/two/GF____/test_1_2_0_authors_creators_two_GF_____schemaorg_object.py
+++ b/test/1.2.0/authors/two/GF____/test_1_2_0_authors_creators_two_GF_____schemaorg_object.py
@@ -59,6 +59,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'the title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/authors/two/GF____/test_1_2_0_authors_creators_two_GF_____zenodo_object.py
+++ b/test/1.2.0/authors/two/GF____/test_1_2_0_authors_creators_two_GF_____zenodo_object.py
@@ -49,5 +49,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'the title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/doi-identifiers/DI/.zenodo.json
+++ b/test/1.2.0/doi-identifiers/DI/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/doi-identifiers/DI/codemeta.json
+++ b/test/1.2.0/doi-identifiers/DI/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/doi-identifiers/DI/schemaorg.json
+++ b/test/1.2.0/doi-identifiers/DI/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/doi-identifiers/DI/test_1_2_0_doi_identifiers_DI_codemeta_object.py
+++ b/test/1.2.0/doi-identifiers/DI/test_1_2_0_doi_identifiers_DI_codemeta_object.py
@@ -54,6 +54,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url is None
 

--- a/test/1.2.0/doi-identifiers/DI/test_1_2_0_doi_identifiers_DI_schemaorg_object.py
+++ b/test/1.2.0/doi-identifiers/DI/test_1_2_0_doi_identifiers_DI_schemaorg_object.py
@@ -54,6 +54,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/doi-identifiers/DI/test_1_2_0_doi_identifiers_DI_zenodo_object.py
+++ b/test/1.2.0/doi-identifiers/DI/test_1_2_0_doi_identifiers_DI_zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/doi-identifiers/D_/.zenodo.json
+++ b/test/1.2.0/doi-identifiers/D_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/doi-identifiers/D_/codemeta.json
+++ b/test/1.2.0/doi-identifiers/D_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/doi-identifiers/D_/schemaorg.json
+++ b/test/1.2.0/doi-identifiers/D_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/doi-identifiers/D_/test_1_2_0_doi_identifiers_D__codemeta_object.py
+++ b/test/1.2.0/doi-identifiers/D_/test_1_2_0_doi_identifiers_D__codemeta_object.py
@@ -54,6 +54,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url is None
 

--- a/test/1.2.0/doi-identifiers/D_/test_1_2_0_doi_identifiers_D__schemaorg_object.py
+++ b/test/1.2.0/doi-identifiers/D_/test_1_2_0_doi_identifiers_D__schemaorg_object.py
@@ -54,6 +54,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/doi-identifiers/D_/test_1_2_0_doi_identifiers_D__zenodo_object.py
+++ b/test/1.2.0/doi-identifiers/D_/test_1_2_0_doi_identifiers_D__zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/doi-identifiers/_I/.zenodo.json
+++ b/test/1.2.0/doi-identifiers/_I/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/doi-identifiers/_I/codemeta.json
+++ b/test/1.2.0/doi-identifiers/_I/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/doi-identifiers/_I/schemaorg.json
+++ b/test/1.2.0/doi-identifiers/_I/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/doi-identifiers/_I/test_1_2_0_doi_identifiers__I_codemeta_object.py
+++ b/test/1.2.0/doi-identifiers/_I/test_1_2_0_doi_identifiers__I_codemeta_object.py
@@ -54,6 +54,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url is None
 

--- a/test/1.2.0/doi-identifiers/_I/test_1_2_0_doi_identifiers__I_schemaorg_object.py
+++ b/test/1.2.0/doi-identifiers/_I/test_1_2_0_doi_identifiers__I_schemaorg_object.py
@@ -54,6 +54,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/doi-identifiers/_I/test_1_2_0_doi_identifiers__I_zenodo_object.py
+++ b/test/1.2.0/doi-identifiers/_I/test_1_2_0_doi_identifiers__I_zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/doi-identifiers/__/.zenodo.json
+++ b/test/1.2.0/doi-identifiers/__/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/doi-identifiers/__/codemeta.json
+++ b/test/1.2.0/doi-identifiers/__/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/doi-identifiers/__/schemaorg.json
+++ b/test/1.2.0/doi-identifiers/__/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/doi-identifiers/__/test_1_2_0_doi_identifiers____codemeta_object.py
+++ b/test/1.2.0/doi-identifiers/__/test_1_2_0_doi_identifiers____codemeta_object.py
@@ -54,6 +54,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url is None
 

--- a/test/1.2.0/doi-identifiers/__/test_1_2_0_doi_identifiers____schemaorg_object.py
+++ b/test/1.2.0/doi-identifiers/__/test_1_2_0_doi_identifiers____schemaorg_object.py
@@ -54,6 +54,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/doi-identifiers/__/test_1_2_0_doi_identifiers____zenodo_object.py
+++ b/test/1.2.0/doi-identifiers/__/test_1_2_0_doi_identifiers____zenodo_object.py
@@ -46,5 +46,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/type/none/.zenodo.json
+++ b/test/1.2.0/type/none/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "The name"
     }
   ],
-  "title": "The title"
+  "title": "The title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/type/none/schemaorg.json
+++ b/test/1.2.0/type/none/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/type/none/test_1_2_0_type_none_schemaorg_object.py
+++ b/test/1.2.0/type/none/test_1_2_0_type_none_schemaorg_object.py
@@ -58,8 +58,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object.add_urls().url is None
 
     def test_upload_type(self, schemaorg_object):
-        assert schemaorg_object.add_type().type == "CreativeWork"
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
 
     def test_version(self, schemaorg_object):
         assert schemaorg_object.add_version().version is None
-

--- a/test/1.2.0/type/none/test_1_2_0_type_none_zenodo_object.py
+++ b/test/1.2.0/type/none/test_1_2_0_type_none_zenodo_object.py
@@ -50,4 +50,4 @@ class TestZenodoObject(Contract):
         assert zenodo_object.add_version().version is None
 
     def test_upload_type(self, zenodo_object):
-        assert zenodo_object.add_upload_type().upload_type is None
+        assert zenodo_object.add_upload_type().upload_type == "software"

--- a/test/1.2.0/urls/IRACU/.zenodo.json
+++ b/test/1.2.0/urls/IRACU/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/IRACU/codemeta.json
+++ b/test/1.2.0/urls/IRACU/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IRACU/schemaorg.json
+++ b/test/1.2.0/urls/IRACU/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IRACU/test_1_2_0_urls_IRACU_codemeta_object.py
+++ b/test/1.2.0/urls/IRACU/test_1_2_0_urls_IRACU_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IRACU/test_1_2_0_urls_IRACU_schemaorg_object.py
+++ b/test/1.2.0/urls/IRACU/test_1_2_0_urls_IRACU_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IRACU/test_1_2_0_urls_IRACU_zenodo_object.py
+++ b/test/1.2.0/urls/IRACU/test_1_2_0_urls_IRACU_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/IRAC_/.zenodo.json
+++ b/test/1.2.0/urls/IRAC_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/IRAC_/codemeta.json
+++ b/test/1.2.0/urls/IRAC_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IRAC_/schemaorg.json
+++ b/test/1.2.0/urls/IRAC_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IRAC_/test_1_2_0_urls_IRAC__codemeta_object.py
+++ b/test/1.2.0/urls/IRAC_/test_1_2_0_urls_IRAC__codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IRAC_/test_1_2_0_urls_IRAC__schemaorg_object.py
+++ b/test/1.2.0/urls/IRAC_/test_1_2_0_urls_IRAC__schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IRAC_/test_1_2_0_urls_IRAC__zenodo_object.py
+++ b/test/1.2.0/urls/IRAC_/test_1_2_0_urls_IRAC__zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/IRA_U/.zenodo.json
+++ b/test/1.2.0/urls/IRA_U/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/IRA_U/codemeta.json
+++ b/test/1.2.0/urls/IRA_U/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IRA_U/schemaorg.json
+++ b/test/1.2.0/urls/IRA_U/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IRA_U/test_1_2_0_urls_IRA_U_codemeta_object.py
+++ b/test/1.2.0/urls/IRA_U/test_1_2_0_urls_IRA_U_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IRA_U/test_1_2_0_urls_IRA_U_schemaorg_object.py
+++ b/test/1.2.0/urls/IRA_U/test_1_2_0_urls_IRA_U_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IRA_U/test_1_2_0_urls_IRA_U_zenodo_object.py
+++ b/test/1.2.0/urls/IRA_U/test_1_2_0_urls_IRA_U_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/IRA__/.zenodo.json
+++ b/test/1.2.0/urls/IRA__/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/IRA__/codemeta.json
+++ b/test/1.2.0/urls/IRA__/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IRA__/schemaorg.json
+++ b/test/1.2.0/urls/IRA__/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IRA__/test_1_2_0_urls_IRA___codemeta_object.py
+++ b/test/1.2.0/urls/IRA__/test_1_2_0_urls_IRA___codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IRA__/test_1_2_0_urls_IRA___schemaorg_object.py
+++ b/test/1.2.0/urls/IRA__/test_1_2_0_urls_IRA___schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IRA__/test_1_2_0_urls_IRA___zenodo_object.py
+++ b/test/1.2.0/urls/IRA__/test_1_2_0_urls_IRA___zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/IR_CU/.zenodo.json
+++ b/test/1.2.0/urls/IR_CU/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/IR_CU/codemeta.json
+++ b/test/1.2.0/urls/IR_CU/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IR_CU/schemaorg.json
+++ b/test/1.2.0/urls/IR_CU/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IR_CU/test_1_2_0_urls_IR_CU_codemeta_object.py
+++ b/test/1.2.0/urls/IR_CU/test_1_2_0_urls_IR_CU_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IR_CU/test_1_2_0_urls_IR_CU_schemaorg_object.py
+++ b/test/1.2.0/urls/IR_CU/test_1_2_0_urls_IR_CU_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IR_CU/test_1_2_0_urls_IR_CU_zenodo_object.py
+++ b/test/1.2.0/urls/IR_CU/test_1_2_0_urls_IR_CU_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/IR_C_/.zenodo.json
+++ b/test/1.2.0/urls/IR_C_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/IR_C_/codemeta.json
+++ b/test/1.2.0/urls/IR_C_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IR_C_/schemaorg.json
+++ b/test/1.2.0/urls/IR_C_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IR_C_/test_1_2_0_urls_IR_C__codemeta_object.py
+++ b/test/1.2.0/urls/IR_C_/test_1_2_0_urls_IR_C__codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IR_C_/test_1_2_0_urls_IR_C__schemaorg_object.py
+++ b/test/1.2.0/urls/IR_C_/test_1_2_0_urls_IR_C__schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IR_C_/test_1_2_0_urls_IR_C__zenodo_object.py
+++ b/test/1.2.0/urls/IR_C_/test_1_2_0_urls_IR_C__zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/IR__U/.zenodo.json
+++ b/test/1.2.0/urls/IR__U/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/IR__U/codemeta.json
+++ b/test/1.2.0/urls/IR__U/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IR__U/schemaorg.json
+++ b/test/1.2.0/urls/IR__U/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IR__U/test_1_2_0_urls_IR__U_codemeta_object.py
+++ b/test/1.2.0/urls/IR__U/test_1_2_0_urls_IR__U_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IR__U/test_1_2_0_urls_IR__U_schemaorg_object.py
+++ b/test/1.2.0/urls/IR__U/test_1_2_0_urls_IR__U_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IR__U/test_1_2_0_urls_IR__U_zenodo_object.py
+++ b/test/1.2.0/urls/IR__U/test_1_2_0_urls_IR__U_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/IR___/.zenodo.json
+++ b/test/1.2.0/urls/IR___/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/IR___/codemeta.json
+++ b/test/1.2.0/urls/IR___/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IR___/schemaorg.json
+++ b/test/1.2.0/urls/IR___/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/IR___/test_1_2_0_urls_IR____codemeta_object.py
+++ b/test/1.2.0/urls/IR___/test_1_2_0_urls_IR____codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IR___/test_1_2_0_urls_IR____schemaorg_object.py
+++ b/test/1.2.0/urls/IR___/test_1_2_0_urls_IR____schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/IR___/test_1_2_0_urls_IR____zenodo_object.py
+++ b/test/1.2.0/urls/IR___/test_1_2_0_urls_IR____zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/I_ACU/.zenodo.json
+++ b/test/1.2.0/urls/I_ACU/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/I_ACU/codemeta.json
+++ b/test/1.2.0/urls/I_ACU/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I_ACU/schemaorg.json
+++ b/test/1.2.0/urls/I_ACU/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I_ACU/test_1_2_0_urls_I_ACU_codemeta_object.py
+++ b/test/1.2.0/urls/I_ACU/test_1_2_0_urls_I_ACU_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I_ACU/test_1_2_0_urls_I_ACU_schemaorg_object.py
+++ b/test/1.2.0/urls/I_ACU/test_1_2_0_urls_I_ACU_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I_ACU/test_1_2_0_urls_I_ACU_zenodo_object.py
+++ b/test/1.2.0/urls/I_ACU/test_1_2_0_urls_I_ACU_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/I_AC_/.zenodo.json
+++ b/test/1.2.0/urls/I_AC_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/I_AC_/codemeta.json
+++ b/test/1.2.0/urls/I_AC_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I_AC_/schemaorg.json
+++ b/test/1.2.0/urls/I_AC_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I_AC_/test_1_2_0_urls_I_AC__codemeta_object.py
+++ b/test/1.2.0/urls/I_AC_/test_1_2_0_urls_I_AC__codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I_AC_/test_1_2_0_urls_I_AC__schemaorg_object.py
+++ b/test/1.2.0/urls/I_AC_/test_1_2_0_urls_I_AC__schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I_AC_/test_1_2_0_urls_I_AC__zenodo_object.py
+++ b/test/1.2.0/urls/I_AC_/test_1_2_0_urls_I_AC__zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/I_A_U/.zenodo.json
+++ b/test/1.2.0/urls/I_A_U/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/I_A_U/codemeta.json
+++ b/test/1.2.0/urls/I_A_U/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I_A_U/schemaorg.json
+++ b/test/1.2.0/urls/I_A_U/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I_A_U/test_1_2_0_urls_I_A_U_codemeta_object.py
+++ b/test/1.2.0/urls/I_A_U/test_1_2_0_urls_I_A_U_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I_A_U/test_1_2_0_urls_I_A_U_schemaorg_object.py
+++ b/test/1.2.0/urls/I_A_U/test_1_2_0_urls_I_A_U_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I_A_U/test_1_2_0_urls_I_A_U_zenodo_object.py
+++ b/test/1.2.0/urls/I_A_U/test_1_2_0_urls_I_A_U_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/I_A__/.zenodo.json
+++ b/test/1.2.0/urls/I_A__/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/I_A__/codemeta.json
+++ b/test/1.2.0/urls/I_A__/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I_A__/schemaorg.json
+++ b/test/1.2.0/urls/I_A__/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I_A__/test_1_2_0_urls_I_A___codemeta_object.py
+++ b/test/1.2.0/urls/I_A__/test_1_2_0_urls_I_A___codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I_A__/test_1_2_0_urls_I_A___schemaorg_object.py
+++ b/test/1.2.0/urls/I_A__/test_1_2_0_urls_I_A___schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I_A__/test_1_2_0_urls_I_A___zenodo_object.py
+++ b/test/1.2.0/urls/I_A__/test_1_2_0_urls_I_A___zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/I__CU/.zenodo.json
+++ b/test/1.2.0/urls/I__CU/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/I__CU/codemeta.json
+++ b/test/1.2.0/urls/I__CU/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I__CU/schemaorg.json
+++ b/test/1.2.0/urls/I__CU/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I__CU/test_1_2_0_urls_I__CU_codemeta_object.py
+++ b/test/1.2.0/urls/I__CU/test_1_2_0_urls_I__CU_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I__CU/test_1_2_0_urls_I__CU_schemaorg_object.py
+++ b/test/1.2.0/urls/I__CU/test_1_2_0_urls_I__CU_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I__CU/test_1_2_0_urls_I__CU_zenodo_object.py
+++ b/test/1.2.0/urls/I__CU/test_1_2_0_urls_I__CU_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/I__C_/.zenodo.json
+++ b/test/1.2.0/urls/I__C_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/I__C_/codemeta.json
+++ b/test/1.2.0/urls/I__C_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I__C_/schemaorg.json
+++ b/test/1.2.0/urls/I__C_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I__C_/test_1_2_0_urls_I__C__codemeta_object.py
+++ b/test/1.2.0/urls/I__C_/test_1_2_0_urls_I__C__codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I__C_/test_1_2_0_urls_I__C__schemaorg_object.py
+++ b/test/1.2.0/urls/I__C_/test_1_2_0_urls_I__C__schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I__C_/test_1_2_0_urls_I__C__zenodo_object.py
+++ b/test/1.2.0/urls/I__C_/test_1_2_0_urls_I__C__zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/I___U/.zenodo.json
+++ b/test/1.2.0/urls/I___U/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/I___U/codemeta.json
+++ b/test/1.2.0/urls/I___U/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I___U/schemaorg.json
+++ b/test/1.2.0/urls/I___U/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I___U/test_1_2_0_urls_I___U_codemeta_object.py
+++ b/test/1.2.0/urls/I___U/test_1_2_0_urls_I___U_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I___U/test_1_2_0_urls_I___U_schemaorg_object.py
+++ b/test/1.2.0/urls/I___U/test_1_2_0_urls_I___U_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I___U/test_1_2_0_urls_I___U_zenodo_object.py
+++ b/test/1.2.0/urls/I___U/test_1_2_0_urls_I___U_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/I____/.zenodo.json
+++ b/test/1.2.0/urls/I____/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/I____/codemeta.json
+++ b/test/1.2.0/urls/I____/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I____/schemaorg.json
+++ b/test/1.2.0/urls/I____/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/I____/test_1_2_0_urls_I_____codemeta_object.py
+++ b/test/1.2.0/urls/I____/test_1_2_0_urls_I_____codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I____/test_1_2_0_urls_I_____schemaorg_object.py
+++ b/test/1.2.0/urls/I____/test_1_2_0_urls_I_____schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-identifiers"
 

--- a/test/1.2.0/urls/I____/test_1_2_0_urls_I_____zenodo_object.py
+++ b/test/1.2.0/urls/I____/test_1_2_0_urls_I_____zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_RACU/.zenodo.json
+++ b/test/1.2.0/urls/_RACU/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_RACU/codemeta.json
+++ b/test/1.2.0/urls/_RACU/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_RACU/schemaorg.json
+++ b/test/1.2.0/urls/_RACU/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_RACU/test_1_2_0_urls__RACU_codemeta_object.py
+++ b/test/1.2.0/urls/_RACU/test_1_2_0_urls__RACU_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/_RACU/test_1_2_0_urls__RACU_schemaorg_object.py
+++ b/test/1.2.0/urls/_RACU/test_1_2_0_urls__RACU_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/_RACU/test_1_2_0_urls__RACU_zenodo_object.py
+++ b/test/1.2.0/urls/_RACU/test_1_2_0_urls__RACU_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_RAC_/.zenodo.json
+++ b/test/1.2.0/urls/_RAC_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_RAC_/codemeta.json
+++ b/test/1.2.0/urls/_RAC_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_RAC_/schemaorg.json
+++ b/test/1.2.0/urls/_RAC_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_RAC_/test_1_2_0_urls__RAC__codemeta_object.py
+++ b/test/1.2.0/urls/_RAC_/test_1_2_0_urls__RAC__codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-repository"
 

--- a/test/1.2.0/urls/_RAC_/test_1_2_0_urls__RAC__schemaorg_object.py
+++ b/test/1.2.0/urls/_RAC_/test_1_2_0_urls__RAC__schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-repository"
 

--- a/test/1.2.0/urls/_RAC_/test_1_2_0_urls__RAC__zenodo_object.py
+++ b/test/1.2.0/urls/_RAC_/test_1_2_0_urls__RAC__zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_RA_U/.zenodo.json
+++ b/test/1.2.0/urls/_RA_U/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_RA_U/codemeta.json
+++ b/test/1.2.0/urls/_RA_U/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_RA_U/schemaorg.json
+++ b/test/1.2.0/urls/_RA_U/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_RA_U/test_1_2_0_urls__RA_U_codemeta_object.py
+++ b/test/1.2.0/urls/_RA_U/test_1_2_0_urls__RA_U_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/_RA_U/test_1_2_0_urls__RA_U_schemaorg_object.py
+++ b/test/1.2.0/urls/_RA_U/test_1_2_0_urls__RA_U_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/_RA_U/test_1_2_0_urls__RA_U_zenodo_object.py
+++ b/test/1.2.0/urls/_RA_U/test_1_2_0_urls__RA_U_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_RA__/.zenodo.json
+++ b/test/1.2.0/urls/_RA__/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_RA__/codemeta.json
+++ b/test/1.2.0/urls/_RA__/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_RA__/schemaorg.json
+++ b/test/1.2.0/urls/_RA__/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_RA__/test_1_2_0_urls__RA___codemeta_object.py
+++ b/test/1.2.0/urls/_RA__/test_1_2_0_urls__RA___codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-repository-artifact"
 

--- a/test/1.2.0/urls/_RA__/test_1_2_0_urls__RA___schemaorg_object.py
+++ b/test/1.2.0/urls/_RA__/test_1_2_0_urls__RA___schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-repository-artifact"
 

--- a/test/1.2.0/urls/_RA__/test_1_2_0_urls__RA___zenodo_object.py
+++ b/test/1.2.0/urls/_RA__/test_1_2_0_urls__RA___zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_R_CU/.zenodo.json
+++ b/test/1.2.0/urls/_R_CU/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_R_CU/codemeta.json
+++ b/test/1.2.0/urls/_R_CU/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_R_CU/schemaorg.json
+++ b/test/1.2.0/urls/_R_CU/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_R_CU/test_1_2_0_urls__R_CU_codemeta_object.py
+++ b/test/1.2.0/urls/_R_CU/test_1_2_0_urls__R_CU_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/_R_CU/test_1_2_0_urls__R_CU_schemaorg_object.py
+++ b/test/1.2.0/urls/_R_CU/test_1_2_0_urls__R_CU_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/_R_CU/test_1_2_0_urls__R_CU_zenodo_object.py
+++ b/test/1.2.0/urls/_R_CU/test_1_2_0_urls__R_CU_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_R_C_/.zenodo.json
+++ b/test/1.2.0/urls/_R_C_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_R_C_/codemeta.json
+++ b/test/1.2.0/urls/_R_C_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_R_C_/schemaorg.json
+++ b/test/1.2.0/urls/_R_C_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_R_C_/test_1_2_0_urls__R_C__codemeta_object.py
+++ b/test/1.2.0/urls/_R_C_/test_1_2_0_urls__R_C__codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-repository"
 

--- a/test/1.2.0/urls/_R_C_/test_1_2_0_urls__R_C__schemaorg_object.py
+++ b/test/1.2.0/urls/_R_C_/test_1_2_0_urls__R_C__schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-repository"
 

--- a/test/1.2.0/urls/_R_C_/test_1_2_0_urls__R_C__zenodo_object.py
+++ b/test/1.2.0/urls/_R_C_/test_1_2_0_urls__R_C__zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_R__U/.zenodo.json
+++ b/test/1.2.0/urls/_R__U/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_R__U/codemeta.json
+++ b/test/1.2.0/urls/_R__U/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_R__U/schemaorg.json
+++ b/test/1.2.0/urls/_R__U/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_R__U/test_1_2_0_urls__R__U_codemeta_object.py
+++ b/test/1.2.0/urls/_R__U/test_1_2_0_urls__R__U_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/_R__U/test_1_2_0_urls__R__U_schemaorg_object.py
+++ b/test/1.2.0/urls/_R__U/test_1_2_0_urls__R__U_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/_R__U/test_1_2_0_urls__R__U_zenodo_object.py
+++ b/test/1.2.0/urls/_R__U/test_1_2_0_urls__R__U_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_R___/.zenodo.json
+++ b/test/1.2.0/urls/_R___/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_R___/codemeta.json
+++ b/test/1.2.0/urls/_R___/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_R___/schemaorg.json
+++ b/test/1.2.0/urls/_R___/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_R___/test_1_2_0_urls__R____codemeta_object.py
+++ b/test/1.2.0/urls/_R___/test_1_2_0_urls__R____codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-repository"
 

--- a/test/1.2.0/urls/_R___/test_1_2_0_urls__R____schemaorg_object.py
+++ b/test/1.2.0/urls/_R___/test_1_2_0_urls__R____schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-repository"
 

--- a/test/1.2.0/urls/_R___/test_1_2_0_urls__R____zenodo_object.py
+++ b/test/1.2.0/urls/_R___/test_1_2_0_urls__R____zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/__ACU/.zenodo.json
+++ b/test/1.2.0/urls/__ACU/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/__ACU/codemeta.json
+++ b/test/1.2.0/urls/__ACU/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/__ACU/schemaorg.json
+++ b/test/1.2.0/urls/__ACU/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/__ACU/test_1_2_0_urls___ACU_codemeta_object.py
+++ b/test/1.2.0/urls/__ACU/test_1_2_0_urls___ACU_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/__ACU/test_1_2_0_urls___ACU_schemaorg_object.py
+++ b/test/1.2.0/urls/__ACU/test_1_2_0_urls___ACU_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/__ACU/test_1_2_0_urls___ACU_zenodo_object.py
+++ b/test/1.2.0/urls/__ACU/test_1_2_0_urls___ACU_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/__AC_/.zenodo.json
+++ b/test/1.2.0/urls/__AC_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/__AC_/codemeta.json
+++ b/test/1.2.0/urls/__AC_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/__AC_/schemaorg.json
+++ b/test/1.2.0/urls/__AC_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/__AC_/test_1_2_0_urls___AC__codemeta_object.py
+++ b/test/1.2.0/urls/__AC_/test_1_2_0_urls___AC__codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-repository-artifact"
 

--- a/test/1.2.0/urls/__AC_/test_1_2_0_urls___AC__schemaorg_object.py
+++ b/test/1.2.0/urls/__AC_/test_1_2_0_urls___AC__schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-repository-artifact"
 

--- a/test/1.2.0/urls/__AC_/test_1_2_0_urls___AC__zenodo_object.py
+++ b/test/1.2.0/urls/__AC_/test_1_2_0_urls___AC__zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/__A_U/.zenodo.json
+++ b/test/1.2.0/urls/__A_U/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/__A_U/codemeta.json
+++ b/test/1.2.0/urls/__A_U/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/__A_U/schemaorg.json
+++ b/test/1.2.0/urls/__A_U/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/__A_U/test_1_2_0_urls___A_U_codemeta_object.py
+++ b/test/1.2.0/urls/__A_U/test_1_2_0_urls___A_U_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/__A_U/test_1_2_0_urls___A_U_schemaorg_object.py
+++ b/test/1.2.0/urls/__A_U/test_1_2_0_urls___A_U_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/__A_U/test_1_2_0_urls___A_U_zenodo_object.py
+++ b/test/1.2.0/urls/__A_U/test_1_2_0_urls___A_U_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/__A__/.zenodo.json
+++ b/test/1.2.0/urls/__A__/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/__A__/codemeta.json
+++ b/test/1.2.0/urls/__A__/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/__A__/schemaorg.json
+++ b/test/1.2.0/urls/__A__/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/__A__/test_1_2_0_urls___A___codemeta_object.py
+++ b/test/1.2.0/urls/__A__/test_1_2_0_urls___A___codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-repository-artifact"
 

--- a/test/1.2.0/urls/__A__/test_1_2_0_urls___A___schemaorg_object.py
+++ b/test/1.2.0/urls/__A__/test_1_2_0_urls___A___schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-repository-artifact"
 

--- a/test/1.2.0/urls/__A__/test_1_2_0_urls___A___zenodo_object.py
+++ b/test/1.2.0/urls/__A__/test_1_2_0_urls___A___zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/___CU/.zenodo.json
+++ b/test/1.2.0/urls/___CU/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/___CU/codemeta.json
+++ b/test/1.2.0/urls/___CU/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/___CU/schemaorg.json
+++ b/test/1.2.0/urls/___CU/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/___CU/test_1_2_0_urls____CU_codemeta_object.py
+++ b/test/1.2.0/urls/___CU/test_1_2_0_urls____CU_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/___CU/test_1_2_0_urls____CU_schemaorg_object.py
+++ b/test/1.2.0/urls/___CU/test_1_2_0_urls____CU_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/___CU/test_1_2_0_urls____CU_zenodo_object.py
+++ b/test/1.2.0/urls/___CU/test_1_2_0_urls____CU_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/___C_/.zenodo.json
+++ b/test/1.2.0/urls/___C_/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/___C_/codemeta.json
+++ b/test/1.2.0/urls/___C_/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/___C_/schemaorg.json
+++ b/test/1.2.0/urls/___C_/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/___C_/test_1_2_0_urls____C__codemeta_object.py
+++ b/test/1.2.0/urls/___C_/test_1_2_0_urls____C__codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-repository-code"
 

--- a/test/1.2.0/urls/___C_/test_1_2_0_urls____C__schemaorg_object.py
+++ b/test/1.2.0/urls/___C_/test_1_2_0_urls____C__schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-repository-code"
 

--- a/test/1.2.0/urls/___C_/test_1_2_0_urls____C__zenodo_object.py
+++ b/test/1.2.0/urls/___C_/test_1_2_0_urls____C__zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/____U/.zenodo.json
+++ b/test/1.2.0/urls/____U/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/____U/codemeta.json
+++ b/test/1.2.0/urls/____U/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/____U/schemaorg.json
+++ b/test/1.2.0/urls/____U/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/____U/test_1_2_0_urls_____U_codemeta_object.py
+++ b/test/1.2.0/urls/____U/test_1_2_0_urls_____U_codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/____U/test_1_2_0_urls_____U_schemaorg_object.py
+++ b/test/1.2.0/urls/____U/test_1_2_0_urls_____U_schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url == "https://github.com/the-url-from-url"
 

--- a/test/1.2.0/urls/____U/test_1_2_0_urls_____U_zenodo_object.py
+++ b/test/1.2.0/urls/____U/test_1_2_0_urls_____U_zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None

--- a/test/1.2.0/urls/_____/.zenodo.json
+++ b/test/1.2.0/urls/_____/.zenodo.json
@@ -4,5 +4,6 @@
       "name": "Test author"
     }
   ],
-  "title": "Test title"
+  "title": "Test title",
+  "upload_type": "software"
 }

--- a/test/1.2.0/urls/_____/codemeta.json
+++ b/test/1.2.0/urls/_____/codemeta.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://doi.org/10.5063/schema/codemeta-2.0",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_____/schemaorg.json
+++ b/test/1.2.0/urls/_____/schemaorg.json
@@ -1,6 +1,6 @@
 {
   "@context": "https://schema.org",
-  "@type": "CreativeWork",
+  "@type": "SoftwareSourceCode",
   "author": [
     {
       "@type": "Person",

--- a/test/1.2.0/urls/_____/test_1_2_0_urls_______codemeta_object.py
+++ b/test/1.2.0/urls/_____/test_1_2_0_urls_______codemeta_object.py
@@ -47,6 +47,9 @@ class TestCodemetaObject(Contract):
     def test_name(self, codemeta_object):
         assert codemeta_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, codemeta_object):
+        assert codemeta_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, codemeta_object):
         assert codemeta_object.add_urls().url is None
 

--- a/test/1.2.0/urls/_____/test_1_2_0_urls_______schemaorg_object.py
+++ b/test/1.2.0/urls/_____/test_1_2_0_urls_______schemaorg_object.py
@@ -47,6 +47,9 @@ class TestSchemaorgObject(Contract):
     def test_name(self, schemaorg_object):
         assert schemaorg_object.add_name().name == 'Test title'
 
+    def test_upload_type(self, schemaorg_object):
+        assert schemaorg_object.add_type().type == "SoftwareSourceCode"
+
     def test_url(self, schemaorg_object):
         assert schemaorg_object.add_urls().url is None
 

--- a/test/1.2.0/urls/_____/test_1_2_0_urls_______zenodo_object.py
+++ b/test/1.2.0/urls/_____/test_1_2_0_urls_______zenodo_object.py
@@ -44,5 +44,8 @@ class TestZenodoObject(Contract):
     def test_title(self, zenodo_object):
         assert zenodo_object.add_title().title == 'Test title'
 
+    def test_upload_type(self, zenodo_object):
+        assert zenodo_object.add_upload_type().upload_type == 'software'
+
     def test_version(self, zenodo_object):
         assert zenodo_object.add_version().version is None


### PR DESCRIPTION
This PR corrects schemaorg, zenodo and codemeta converters such that the default behavior is to generate a "type: software" equivalent (even) when the CITATION.cff doesnt specify "software" as its "type". This is because type has default value "software" in CFF 1.2.0.

refs:
- #303