### PR TITLE
entity authors schemaorg

### DIFF
--- a/src/cffconvert/cff_1_x_x/schemaorg_author.py
+++ b/src/cffconvert/cff_1_x_x/schemaorg_author.py
@@ -55,16 +55,16 @@ class SchemaorgAuthor(BaseAuthor):
             '_F__A_E': self._from_last_and_affiliation_and_email,
             '_F___OE': self._from_last_and_orcid_and_email,
             '_F____E': self._from_last_and_email,
-            '__ANAOE': self._from_alias_and_name_and_affiliation_and_orcid_and_email,
-            '__ANA_E': self._from_alias_and_name_and_affiliation_and_email,
+            '__ANAOE': self._from_alias_and_name_and_orcid_and_email,
+            '__ANA_E': self._from_alias_and_name_and_email,
             '__AN_OE': self._from_alias_and_name_and_orcid_and_email,
             '__AN__E': self._from_alias_and_name_and_email,
             '__A_AOE': self._from_alias_and_affiliation_and_orcid_and_email,
             '__A_A_E': self._from_alias_and_affiliation_and_email,
             '__A__OE': self._from_alias_and_orcid_and_email,
             '__A___E': self._from_alias_and_email,
-            '___NAOE': self._from_name_and_affiliation_and_orcid_and_email,
-            '___NA_E': self._from_name_and_affiliation_and_email,
+            '___NAOE': self._from_name_and_orcid_and_email,
+            '___NA_E': self._from_name_and_email,
             '___N_OE': self._from_name_and_orcid_and_email,
             '___N__E': self._from_name_and_email,
             '____AOE': self._from_affiliation_and_orcid_and_email,
@@ -119,16 +119,16 @@ class SchemaorgAuthor(BaseAuthor):
             '_F__A__': self._from_last_and_affiliation,
             '_F___O_': self._from_last_and_orcid,
             '_F_____': self._from_last,
-            '__ANAO_': self._from_alias_and_name_and_affiliation_and_orcid,
-            '__ANA__': self._from_alias_and_name_and_affiliation,
+            '__ANAO_': self._from_alias_and_name_and_orcid,
+            '__ANA__': self._from_alias_and_name,
             '__AN_O_': self._from_alias_and_name_and_orcid,
             '__AN___': self._from_alias_and_name,
             '__A_AO_': self._from_alias_and_affiliation_and_orcid,
             '__A_A__': self._from_alias_and_affiliation,
             '__A__O_': self._from_alias_and_orcid,
             '__A____': self._from_alias,
-            '___NAO_': self._from_name_and_affiliation_and_orcid,
-            '___NA__': self._from_name_and_affiliation,
+            '___NAO_': self._from_name_and_orcid,
+            '___NA__': self._from_name,
             '___N_O_': self._from_name_and_orcid,
             '___N___': self._from_name,
             '____AO_': self._from_affiliation_and_orcid,
@@ -185,31 +185,6 @@ class SchemaorgAuthor(BaseAuthor):
                 'legalName': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
-            'email': self._author.get('email')
-        }
-
-    def _from_alias_and_name_and_affiliation_and_orcid_and_email(self):
-        return {
-            '@id': self._author.get('orcid'),
-            '@type': 'Person',
-            'affiliation': {
-                '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
-            },
-            'alternateName': self._author.get('alias'),
-            'name': self._author.get('name'),
-            'email': self._author.get('email')
-        }
-
-    def _from_alias_and_name_and_affiliation_and_email(self):
-        return {
-            '@type': 'Person',
-            'affiliation': {
-                '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
-            },
-            'alternateName': self._author.get('alias'),
-            'name': self._author.get('name'),
             'email': self._author.get('email')
         }
 
@@ -499,33 +474,10 @@ class SchemaorgAuthor(BaseAuthor):
             'email': self._author.get('email')
         }
 
-    def _from_name_and_affiliation_and_email(self):
-        return {
-            '@type': 'Person',
-            'affiliation': {
-                '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
-            },
-            'name': self._author.get('name'),
-            'email': self._author.get('email')
-        }
-
-    def _from_name_and_affiliation_and_orcid_and_email(self):
-        return {
-            '@id': self._author.get('orcid'),
-            '@type': 'Person',
-            'affiliation': {
-                '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
-            },
-            'name': self._author.get('name'),
-            'email': self._author.get('email')
-        }
-
     def _from_name_and_orcid_and_email(self):
         return {
             '@id': self._author.get('orcid'),
-            '@type': 'Person',
+            '@type': 'Organization',
             'name': self._author.get('name'),
             'email': self._author.get('email')
         }
@@ -581,29 +533,6 @@ class SchemaorgAuthor(BaseAuthor):
                 'legalName': self._author.get('affiliation')
             },
             'alternateName': self._author.get('alias'),
-        }
-
-    def _from_alias_and_name_and_affiliation_and_orcid(self):
-        return {
-            '@id': self._author.get('orcid'),
-            '@type': 'Person',
-            'affiliation': {
-                '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
-            },
-            'alternateName': self._author.get('alias'),
-            'name': self._author.get('name')
-        }
-
-    def _from_alias_and_name_and_affiliation(self):
-        return {
-            '@type': 'Person',
-            'affiliation': {
-                '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
-            },
-            'alternateName': self._author.get('alias'),
-            'name': self._author.get('name')
         }
 
     def _from_alias_and_name_and_orcid(self):
@@ -854,28 +783,7 @@ class SchemaorgAuthor(BaseAuthor):
 
     def _from_name(self):
         return {
-            '@type': 'Person',
-            'name': self._author.get('name')
-        }
-
-    def _from_name_and_affiliation(self):
-        return {
-            '@type': 'Person',
-            'affiliation': {
-                '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
-            },
-            'name': self._author.get('name')
-        }
-
-    def _from_name_and_affiliation_and_orcid(self):
-        return {
-            '@id': self._author.get('orcid'),
-            '@type': 'Person',
-            'affiliation': {
-                '@type': 'Organization',
-                'legalName': self._author.get('affiliation')
-            },
+            '@type': 'Organization',
             'name': self._author.get('name')
         }
 

--- a/tests/cff_1_2_0/authors/one/___N___/schemaorg.json
+++ b/tests/cff_1_2_0/authors/one/___N___/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "The soccer team members"
     }
   ],

--- a/tests/cff_1_2_0/authors/one/___N___/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/authors/one/___N___/test_schemaorg_object.py
@@ -23,7 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "The soccer team members"
         }]
 

--- a/tests/cff_1_2_0/identifiers/DI/codemeta.json
+++ b/tests/cff_1_2_0/identifiers/DI/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/DI/schemaorg.json
+++ b/tests/cff_1_2_0/identifiers/DI/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/DI/test_codemeta_object.py
+++ b/tests/cff_1_2_0/identifiers/DI/test_codemeta_object.py
@@ -23,7 +23,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/identifiers/DI/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/identifiers/DI/test_schemaorg_object.py
@@ -23,7 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/identifiers/D_/codemeta.json
+++ b/tests/cff_1_2_0/identifiers/D_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/D_/schemaorg.json
+++ b/tests/cff_1_2_0/identifiers/D_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/D_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/identifiers/D_/test_codemeta_object.py
@@ -23,7 +23,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/identifiers/D_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/identifiers/D_/test_schemaorg_object.py
@@ -23,7 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/identifiers/_I/codemeta.json
+++ b/tests/cff_1_2_0/identifiers/_I/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/_I/schemaorg.json
+++ b/tests/cff_1_2_0/identifiers/_I/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/_I/test_codemeta_object.py
+++ b/tests/cff_1_2_0/identifiers/_I/test_codemeta_object.py
@@ -23,7 +23,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/identifiers/_I/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/identifiers/_I/test_schemaorg_object.py
@@ -23,7 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/identifiers/__/codemeta.json
+++ b/tests/cff_1_2_0/identifiers/__/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/__/schemaorg.json
+++ b/tests/cff_1_2_0/identifiers/__/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/identifiers/__/test_codemeta_object.py
+++ b/tests/cff_1_2_0/identifiers/__/test_codemeta_object.py
@@ -23,7 +23,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/identifiers/__/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/identifiers/__/test_schemaorg_object.py
@@ -23,7 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/types/dataset/schemaorg.json
+++ b/tests/cff_1_2_0/types/dataset/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "Dataset",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "The name"
     }
   ],

--- a/tests/cff_1_2_0/types/dataset/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/types/dataset/test_schemaorg_object.py
@@ -23,7 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "The name"
         }]
 

--- a/tests/cff_1_2_0/types/none/schemaorg.json
+++ b/tests/cff_1_2_0/types/none/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "The name"
     }
   ],

--- a/tests/cff_1_2_0/types/none/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/types/none/test_schemaorg_object.py
@@ -23,7 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "The name"
         }]
 

--- a/tests/cff_1_2_0/types/software/schemaorg.json
+++ b/tests/cff_1_2_0/types/software/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "The name"
     }
   ],

--- a/tests/cff_1_2_0/types/software/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/types/software/test_schemaorg_object.py
@@ -23,7 +23,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "The name"
         }]
 

--- a/tests/cff_1_2_0/urls/IRACU/codemeta.json
+++ b/tests/cff_1_2_0/urls/IRACU/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRACU/schemaorg.json
+++ b/tests/cff_1_2_0/urls/IRACU/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRACU/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/IRACU/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IRACU/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/IRACU/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IRAC_/codemeta.json
+++ b/tests/cff_1_2_0/urls/IRAC_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRAC_/schemaorg.json
+++ b/tests/cff_1_2_0/urls/IRAC_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRAC_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/IRAC_/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IRAC_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/IRAC_/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IRA_U/codemeta.json
+++ b/tests/cff_1_2_0/urls/IRA_U/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRA_U/schemaorg.json
+++ b/tests/cff_1_2_0/urls/IRA_U/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRA_U/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/IRA_U/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IRA_U/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/IRA_U/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IRA__/codemeta.json
+++ b/tests/cff_1_2_0/urls/IRA__/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRA__/schemaorg.json
+++ b/tests/cff_1_2_0/urls/IRA__/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IRA__/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/IRA__/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IRA__/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/IRA__/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IR_CU/codemeta.json
+++ b/tests/cff_1_2_0/urls/IR_CU/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR_CU/schemaorg.json
+++ b/tests/cff_1_2_0/urls/IR_CU/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR_CU/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/IR_CU/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IR_CU/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/IR_CU/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IR_C_/codemeta.json
+++ b/tests/cff_1_2_0/urls/IR_C_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR_C_/schemaorg.json
+++ b/tests/cff_1_2_0/urls/IR_C_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR_C_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/IR_C_/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IR_C_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/IR_C_/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IR__U/codemeta.json
+++ b/tests/cff_1_2_0/urls/IR__U/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR__U/schemaorg.json
+++ b/tests/cff_1_2_0/urls/IR__U/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR__U/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/IR__U/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IR__U/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/IR__U/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IR___/codemeta.json
+++ b/tests/cff_1_2_0/urls/IR___/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR___/schemaorg.json
+++ b/tests/cff_1_2_0/urls/IR___/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/IR___/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/IR___/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/IR___/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/IR___/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I_ACU/codemeta.json
+++ b/tests/cff_1_2_0/urls/I_ACU/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_ACU/schemaorg.json
+++ b/tests/cff_1_2_0/urls/I_ACU/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_ACU/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/I_ACU/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I_ACU/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/I_ACU/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I_AC_/codemeta.json
+++ b/tests/cff_1_2_0/urls/I_AC_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_AC_/schemaorg.json
+++ b/tests/cff_1_2_0/urls/I_AC_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_AC_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/I_AC_/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I_AC_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/I_AC_/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I_A_U/codemeta.json
+++ b/tests/cff_1_2_0/urls/I_A_U/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_A_U/schemaorg.json
+++ b/tests/cff_1_2_0/urls/I_A_U/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_A_U/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/I_A_U/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I_A_U/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/I_A_U/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I_A__/codemeta.json
+++ b/tests/cff_1_2_0/urls/I_A__/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_A__/schemaorg.json
+++ b/tests/cff_1_2_0/urls/I_A__/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I_A__/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/I_A__/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I_A__/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/I_A__/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I__CU/codemeta.json
+++ b/tests/cff_1_2_0/urls/I__CU/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I__CU/schemaorg.json
+++ b/tests/cff_1_2_0/urls/I__CU/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I__CU/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/I__CU/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I__CU/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/I__CU/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I__C_/codemeta.json
+++ b/tests/cff_1_2_0/urls/I__C_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I__C_/schemaorg.json
+++ b/tests/cff_1_2_0/urls/I__C_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I__C_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/I__C_/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I__C_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/I__C_/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I___U/codemeta.json
+++ b/tests/cff_1_2_0/urls/I___U/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I___U/schemaorg.json
+++ b/tests/cff_1_2_0/urls/I___U/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I___U/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/I___U/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I___U/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/I___U/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I____/codemeta.json
+++ b/tests/cff_1_2_0/urls/I____/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I____/schemaorg.json
+++ b/tests/cff_1_2_0/urls/I____/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/I____/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/I____/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/I____/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/I____/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_RACU/codemeta.json
+++ b/tests/cff_1_2_0/urls/_RACU/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RACU/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_RACU/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RACU/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_RACU/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_RACU/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_RACU/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_RAC_/codemeta.json
+++ b/tests/cff_1_2_0/urls/_RAC_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RAC_/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_RAC_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RAC_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_RAC_/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_RAC_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_RAC_/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_RA_U/codemeta.json
+++ b/tests/cff_1_2_0/urls/_RA_U/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RA_U/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_RA_U/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RA_U/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_RA_U/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_RA_U/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_RA_U/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_RA__/codemeta.json
+++ b/tests/cff_1_2_0/urls/_RA__/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RA__/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_RA__/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_RA__/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_RA__/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_RA__/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_RA__/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_R_CU/codemeta.json
+++ b/tests/cff_1_2_0/urls/_R_CU/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R_CU/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_R_CU/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R_CU/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_R_CU/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_R_CU/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_R_CU/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_R_C_/codemeta.json
+++ b/tests/cff_1_2_0/urls/_R_C_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R_C_/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_R_C_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R_C_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_R_C_/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_R_C_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_R_C_/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_R__U/codemeta.json
+++ b/tests/cff_1_2_0/urls/_R__U/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R__U/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_R__U/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R__U/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_R__U/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_R__U/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_R__U/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_R___/codemeta.json
+++ b/tests/cff_1_2_0/urls/_R___/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R___/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_R___/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_R___/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_R___/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_R___/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_R___/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/__ACU/codemeta.json
+++ b/tests/cff_1_2_0/urls/__ACU/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/__ACU/schemaorg.json
+++ b/tests/cff_1_2_0/urls/__ACU/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/__ACU/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/__ACU/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/__ACU/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/__ACU/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/__AC_/codemeta.json
+++ b/tests/cff_1_2_0/urls/__AC_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/__AC_/schemaorg.json
+++ b/tests/cff_1_2_0/urls/__AC_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/__AC_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/__AC_/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/__AC_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/__AC_/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/__A_U/codemeta.json
+++ b/tests/cff_1_2_0/urls/__A_U/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/__A_U/schemaorg.json
+++ b/tests/cff_1_2_0/urls/__A_U/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/__A_U/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/__A_U/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/__A_U/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/__A_U/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/__A__/codemeta.json
+++ b/tests/cff_1_2_0/urls/__A__/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/__A__/schemaorg.json
+++ b/tests/cff_1_2_0/urls/__A__/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/__A__/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/__A__/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/__A__/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/__A__/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/___CU/codemeta.json
+++ b/tests/cff_1_2_0/urls/___CU/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/___CU/schemaorg.json
+++ b/tests/cff_1_2_0/urls/___CU/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/___CU/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/___CU/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/___CU/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/___CU/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/___C_/codemeta.json
+++ b/tests/cff_1_2_0/urls/___C_/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/___C_/schemaorg.json
+++ b/tests/cff_1_2_0/urls/___C_/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/___C_/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/___C_/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/___C_/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/___C_/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/____U/codemeta.json
+++ b/tests/cff_1_2_0/urls/____U/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/____U/schemaorg.json
+++ b/tests/cff_1_2_0/urls/____U/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/____U/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/____U/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/____U/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/____U/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_____/codemeta.json
+++ b/tests/cff_1_2_0/urls/_____/codemeta.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_____/schemaorg.json
+++ b/tests/cff_1_2_0/urls/_____/schemaorg.json
@@ -3,7 +3,7 @@
   "@type": "SoftwareSourceCode",
   "author": [
     {
-      "@type": "Person",
+      "@type": "Organization",
       "name": "Test author"
     }
   ],

--- a/tests/cff_1_2_0/urls/_____/test_codemeta_object.py
+++ b/tests/cff_1_2_0/urls/_____/test_codemeta_object.py
@@ -20,7 +20,7 @@ class TestCodemetaObject(Contract):
 
     def test_author(self):
         assert codemeta_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_2_0/urls/_____/test_schemaorg_object.py
+++ b/tests/cff_1_2_0/urls/_____/test_schemaorg_object.py
@@ -20,7 +20,7 @@ class TestSchemaorgObject(Contract):
 
     def test_author(self):
         assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
+            "@type": "Organization",
             "name": "Test author"
         }]
 

--- a/tests/cff_1_x_x/authors/test_keymap_apalike_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_apalike_author.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.apalike_author import ApalikeAuthor
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = ApalikeAuthor(author=None)
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_apalike_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_apalike_author.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.apalike_author import ApalikeAuthor
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(ApalikeAuthor(author=None)._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = ApalikeAuthor(author=None)
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_bibtex_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_bibtex_author.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.bibtex_author import BibtexAuthor
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = BibtexAuthor(author=None)
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_bibtex_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_bibtex_author.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.bibtex_author import BibtexAuthor
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(BibtexAuthor(author=None)._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = BibtexAuthor(author=None)
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_endnote_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_endnote_author.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.endnote_author import EndnoteAuthor
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = EndnoteAuthor(author=None)
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_endnote_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_endnote_author.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.endnote_author import EndnoteAuthor
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(EndnoteAuthor(author=None)._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = EndnoteAuthor(author=None)
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_ris_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_ris_author.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.ris_author import RisAuthor
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = RisAuthor(author=None)
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_ris_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_ris_author.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.ris_author import RisAuthor
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(RisAuthor(author=None)._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = RisAuthor(author=None)
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_schemaorg_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_schemaorg_author.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.schemaorg_author import SchemaorgAuthor
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(SchemaorgAuthor(author=None)._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = SchemaorgAuthor(author=None)
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_schemaorg_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_schemaorg_author.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.schemaorg_author import SchemaorgAuthor
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = SchemaorgAuthor(author=None)
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_zenodo_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_zenodo_author.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.zenodo_author import ZenodoAuthor
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(ZenodoAuthor(author=None)._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = ZenodoAuthor(author=None)
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/authors/test_keymap_zenodo_author.py
+++ b/tests/cff_1_x_x/authors/test_keymap_zenodo_author.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.zenodo_author import ZenodoAuthor
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = ZenodoAuthor(author=None)
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_apalike_url.py
+++ b/tests/cff_1_x_x/urls/test_keymap_apalike_url.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.apalike_url import ApalikeUrl
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(ApalikeUrl({})._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = ApalikeUrl({})
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_apalike_url.py
+++ b/tests/cff_1_x_x/urls/test_keymap_apalike_url.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.apalike_url import ApalikeUrl
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = ApalikeUrl({})
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_bibtex_url.py
+++ b/tests/cff_1_x_x/urls/test_keymap_bibtex_url.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.bibtex_url import BibtexUrl
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = BibtexUrl({})
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_bibtex_url.py
+++ b/tests/cff_1_x_x/urls/test_keymap_bibtex_url.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.bibtex_url import BibtexUrl
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(BibtexUrl({})._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = BibtexUrl({})
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_endnote_url.py
+++ b/tests/cff_1_x_x/urls/test_keymap_endnote_url.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.endnote_url import EndnoteUrl
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(EndnoteUrl({})._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = EndnoteUrl({})
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_endnote_url.py
+++ b/tests/cff_1_x_x/urls/test_keymap_endnote_url.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.endnote_url import EndnoteUrl
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = EndnoteUrl({})
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_ris_url.py
+++ b/tests/cff_1_x_x/urls/test_keymap_ris_url.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.ris_url import RisUrl
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = RisUrl({})
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_ris_url.py
+++ b/tests/cff_1_x_x/urls/test_keymap_ris_url.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.ris_url import RisUrl
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(RisUrl({})._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = RisUrl({})
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_schemaorg_urls.py
+++ b/tests/cff_1_x_x/urls/test_keymap_schemaorg_urls.py
@@ -1,6 +1,7 @@
 # pylint:disable = protected-access
 import types
 import pytest
+import inspect
 from cffconvert.cff_1_x_x.schemaorg_urls import SchemaorgUrls
 from .get_every_key import get_every_key
 
@@ -16,3 +17,11 @@ def test_number_of_keys():
     expected = len(get_every_key())
     actual = len(SchemaorgUrls({})._behaviors)
     assert actual == expected
+
+
+def test_all_methods_used():
+    author = SchemaorgUrls({})
+    used_method_names = [elem.__name__ for elem in author._behaviors.values()]
+    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    for implementation_name in implementation_names:
+        assert implementation_name in used_method_names

--- a/tests/cff_1_x_x/urls/test_keymap_schemaorg_urls.py
+++ b/tests/cff_1_x_x/urls/test_keymap_schemaorg_urls.py
@@ -1,7 +1,7 @@
 # pylint:disable = protected-access
+import inspect
 import types
 import pytest
-import inspect
 from cffconvert.cff_1_x_x.schemaorg_urls import SchemaorgUrls
 from .get_every_key import get_every_key
 
@@ -22,6 +22,8 @@ def test_number_of_keys():
 def test_all_methods_used():
     author = SchemaorgUrls({})
     used_method_names = [elem.__name__ for elem in author._behaviors.values()]
-    implementation_names = [k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")]
+    implementation_names = [
+        k for k, v in inspect.getmembers(author, predicate=inspect.ismethod) if k.startswith("_from")
+    ]
     for implementation_name in implementation_names:
         assert implementation_name in used_method_names


### PR DESCRIPTION
Refs:

- #239

In this PR:

- `schema.org` and `codemeta` now return author of type `Organization` when input author is an entity rather than a person.
- Added tests to keymap tests to verify that there are no unused methods
