### PR TITLE
exit code 1 when failing validation on convert

### DIFF
--- a/src/cffconvert/cli/validate_or_write_output.py
+++ b/src/cffconvert/cli/validate_or_write_output.py
@@ -23,7 +23,7 @@ def validate_or_write_output(outfile, outputformat, validate_only, citation, ver
         except (PykwalifySchemaError, JsonschemaSchemaError):
             print(f"'{citation.src}' does not pass validation. Conversion aborted.")
             ctx = click.get_current_context()
-            ctx.exit()
+            ctx.exit(1)
         outstr = {
             "apalike": citation.as_apalike,
             "bibtex": citation.as_bibtex,


### PR DESCRIPTION
refs:

- #266

In this PR:

- added exit code 1 when failing validation prior to converting 