### PR TITLE
Error message truncated again

### DIFF
--- a/src/cffconvert/cff_1_2_x/citation.py
+++ b/src/cffconvert/cff_1_2_x/citation.py
@@ -85,5 +85,6 @@ class Citation_1_2_x(Contract):  # nopep8
                     "...truncated output...",
                     "Add --verbose flag for full output."
                 ])
-                raise ValidationError(truncated_message) from error
+                # pylint:disable = raise-missing-from
+                raise ValidationError(truncated_message)
             raise


### PR DESCRIPTION
Following a prospector recommendation broke the truncated output for validation errors for CITATION.cff files with `cff-version: 1.2.0`. This PR fixes that again by reverting to the pre-propsector code, and adding a local pylint exception