### PR TITLE
Added caching of cffstr during tests

### DIFF
--- a/tests/lib/cff_1_0_3/a/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/a/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/a/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/a/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/a/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/a/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/a/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/a/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/a/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/a/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/a/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/a/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/a/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/a/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/b/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/b/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/b/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/b/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/b/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/b/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/b/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/b/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/b/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/b/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/b/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/b/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/b/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/b/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/c/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/c/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/c/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/c/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/c/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/c/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/c/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/c/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/c/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/c/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/c/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/c/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/c/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/c/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/d/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/d/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/d/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/d/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/d/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/d/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/d/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/d/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/d/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/d/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/d/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/d/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/d/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/d/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/e/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/e/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/e/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/e/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/e/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/e/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/e/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/e/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/e/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/e/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/e/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/e/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_0_3/e/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/e/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_0_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/a/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/a/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/a/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/a/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/a/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/a/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/a/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/a/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/a/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/a/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/a/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/a/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/a/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/a/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/b/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/b/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/b/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/b/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/b/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/b/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/b/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/b/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/b/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/b/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/b/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/b/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/b/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/b/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/c/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/c/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/c/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/c/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/c/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/c/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/c/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/c/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/c/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/c/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/c/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/c/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/c/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/c/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/d/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/d/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/d/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/d/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/d/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/d/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/d/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/d/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/d/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/d/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/d/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/d/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/d/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/d/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/e/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/e/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/e/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/e/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/e/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/e/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/e/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/e/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/e/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/e/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/e/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/e/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/e/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/e/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/f/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/f/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/f/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/f/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/f/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/f/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/f/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/f/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/f/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/f/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/f/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/f/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/f/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/f/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/g/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/g/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/g/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/g/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/g/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/g/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/g/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/g/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/g/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/g/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/g/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/g/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/g/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/g/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/h/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/h/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/h/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/h/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/h/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/h/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/h/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/h/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/h/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/h/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/h/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/h/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_1_0/h/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/h/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_1_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/identifiers/__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/types/dataset/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/types/dataset/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/types/dataset/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/types/dataset/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/types/none/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/types/none/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/types/none/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/types/none/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/types/software/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/types/software/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/types/software/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/types/software/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR___/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR___/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR___/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/IR___/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I___U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I___U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I___U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I___U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I___U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I___U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I___U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/I____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R___/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R___/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R___/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_R___/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/__A__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___CU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___CU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___C_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___C_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/___C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/____U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/____U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/____U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/____U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/____U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/____U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/____U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_2_0/urls/_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/relation/test_zenodo_related_identifiers.py
+++ b/tests/lib/cff_1_3_0/identifiers/relation/test_zenodo_related_identifiers.py
@@ -1,9 +1,11 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 
 
+@lru_cache
 def get_cffstr():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/types/dataset/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/types/dataset/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/types/dataset/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/types/dataset/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/types/none/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/types/none/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/types/none/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/types/none/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/types/software/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/types/software/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/types/software/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/types/software/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR___/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/IR___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I___U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I___U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I___U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I___U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I___U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I___U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I___U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/I____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R___/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_R___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/__A__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___CU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___CU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___C_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___C_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/___C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/____U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/____U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/____U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/____U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/____U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/____U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/____U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_apalike_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
 from tests.lib.contracts.apalike import Contract
 
 
+@lru_cache
 def apalike_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_bibtex_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from tests.lib.contracts.bibtex import Contract
 
 
+@lru_cache
 def bibtex_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_codemeta_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from tests.lib.contracts.codemeta import Contract
 
 
+@lru_cache
 def codemeta_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_endnote_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
 from tests.lib.contracts.endnote import Contract
 
 
+@lru_cache
 def endnote_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_ris_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.ris import RisObject
 from tests.lib.contracts.ris import Contract
 
 
+@lru_cache
 def ris_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_schemaorg_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 from tests.lib.contracts.schemaorg import Contract
 
 
+@lru_cache
 def schemaorg_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:

--- a/tests/lib/cff_1_3_0/urls/_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_zenodo_object.py
@@ -1,10 +1,12 @@
 import os
+from functools import lru_cache
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_3_x.zenodo import ZenodoObject
 from tests.lib.contracts.zenodo import Contract
 
 
+@lru_cache
 def zenodo_object():
     fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
     with open(fixture, "rt", encoding="utf-8") as f:


### PR DESCRIPTION
This PR adds `lru_cache` based caching for reading cff data from disk during tests. Speedup is about 3x.