### PR TITLE
Add support for biblatex-software

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -105,3 +105,6 @@ ENV/
 # IDE
 .idea
 .vscode
+
+# Vim temp files
+*.swp

--- a/README.dev.md
+++ b/README.dev.md
@@ -66,12 +66,13 @@ Tests pertaining to a specific exporter have been marked accordingly with one of
 `pytest` configuration section in `pyproject.toml`):
 
 1. `apalike`
-2. `bibtex`
-3. `codemeta`
-4. `endnote`
-5. `ris`
-6. `schemaorg`
-7. `zenodo`
+2. `biblatex`
+3. `bibtex`
+4. `codemeta`
+5. `endnote`
+6. `ris`
+7. `schemaorg`
+8. `zenodo`
 
 Additionally, there are markers for CLI tests and for library tests:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -110,6 +110,7 @@ src_paths = ["src", "tests"]
 addopts = "--no-cov --verbose --maxfail=1 --strict-markers --import-mode=importlib --cache-clear --strict-config"
 markers = [
     "apalike: Tests pertaining to 'apalike' export behavior",
+    "biblatex: Tests pertaining to 'biblatex' export behavior",
     "bibtex: Tests pertaining to 'bibtex' export behavior",
     "cli: Tests pertaining to cffconvert's command line interface",
     "codemeta: Tests pertaining to 'codemeta' export behavior",

--- a/src/cffconvert/cli/cli.py
+++ b/src/cffconvert/cli/cli.py
@@ -21,6 +21,7 @@ options = {
     "outputformat": {
         "type": click.Choice([
             "apalike",
+            "biblatex",
             "bibtex",
             "cff",
             "codemeta",

--- a/src/cffconvert/cli/validate_or_write_output.py
+++ b/src/cffconvert/cli/validate_or_write_output.py
@@ -26,6 +26,7 @@ def validate_or_write_output(outfile, outputformat, validate_only, citation, ver
             ctx.exit(1)
         outstr = {
             "apalike": citation.as_apalike,
+            "biblatex": citation.as_biblatex,
             "bibtex": citation.as_bibtex,
             "cff": citation.as_cff,
             "codemeta": citation.as_codemeta,

--- a/src/cffconvert/gcloud/gcloud.py
+++ b/src/cffconvert/gcloud/gcloud.py
@@ -64,13 +64,14 @@ def cffconvert(request):
         outstr += f"Data passes validation according to Citation File Format schema version {citation.cffversion}."
         return Response(outstr, mimetype=mimetype_plain)
 
-    acceptable_output_formats = ["apalike", "bibtex", "cff", "codemeta", "endnote", "schema.org", "ris", "zenodo"]
+    acceptable_output_formats = ["apalike", "biblatex", "bibtex", "cff", "codemeta", "endnote", "schema.org", "ris", "zenodo"]
     if outputformat not in acceptable_output_formats:
         outstr += f"\n\n'outputformat' should be one of [{', '.join(acceptable_output_formats)}]"
         return Response(outstr, mimetype=mimetype_plain)
 
     outstr += {
         "apalike": citation.as_apalike,
+        "biblatex": citation.as_biblatex,
         "bibtex": citation.as_bibtex,
         "cff": citation.as_cff,
         "codemeta": citation.as_codemeta,

--- a/src/cffconvert/lib/cff_1_0_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_0_x/biblatex.py
@@ -1,0 +1,38 @@
+from cffconvert.lib.cff_1_x_x.authors.biblatex import BiblatexAuthor
+from cffconvert.lib.cff_1_x_x.biblatex import BiblatexObjectShared as Shared
+from cffconvert.lib.cff_1_x_x.urls.biblatex import BiblatexUrl
+
+
+class BiblatexObject(Shared):
+
+    supported_cff_versions = [
+        "1.0.1",
+        "1.0.2",
+        "1.0.3"
+    ]
+
+    def add_author(self):
+        authors_cff = self.cffobj.get("authors", [])
+        authors_biblatex = [BiblatexAuthor(a).as_string() for a in authors_cff]
+        authors_biblatex_filtered = [a for a in authors_biblatex if a is not None]
+        self.author = "author = {" + " and ".join(authors_biblatex_filtered) + "}"
+        return self
+
+    def add_doi(self):
+        if "doi" in self.cffobj.keys():
+            self.doi = "doi = {" + self.cffobj["doi"] + "}"
+        return self
+
+    def add_month(self):
+        if "date-released" in self.cffobj.keys():
+            self.month = "month = {" + str(self.cffobj["date-released"].month) + "}"
+        return self
+
+    def add_url(self):
+        self.url = BiblatexUrl(self.cffobj).as_string()
+        return self
+
+    def add_year(self):
+        if "date-released" in self.cffobj.keys():
+            self.year = "year = {" + str(self.cffobj["date-released"].year) + "}"
+        return self

--- a/src/cffconvert/lib/cff_1_0_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_0_x/biblatex.py
@@ -36,3 +36,8 @@ class BiblatexObject(Shared):
         if "date-released" in self.cffobj.keys():
             self.year = "year = {" + str(self.cffobj["date-released"].year) + "}"
         return self
+
+    def add_date(self):
+        if "date-released" in self.cffobj.keys():
+            self.date = "date = {" + self.cffobj["date-released"].isoformat() + "}"
+        return self

--- a/src/cffconvert/lib/cff_1_0_x/citation.py
+++ b/src/cffconvert/lib/cff_1_0_x/citation.py
@@ -3,6 +3,7 @@ from pykwalify.core import Core
 from ruamel.yaml import SafeConstructor
 from ruamel.yaml import YAML
 from cffconvert.lib.cff_1_0_x.apalike import ApalikeObject
+from cffconvert.lib.cff_1_0_x.biblatex import BiblatexObject
 from cffconvert.lib.cff_1_0_x.bibtex import BibtexObject
 from cffconvert.lib.cff_1_0_x.codemeta import CodemetaObject
 from cffconvert.lib.cff_1_0_x.endnote import EndnoteObject
@@ -56,6 +57,9 @@ class Citation_1_0_x(Contract):  # noqa
 
     def as_apalike(self):
         return ApalikeObject(self.cffobj).as_string()
+
+    def as_biblatex(self):
+        return BiblatexObject(self.cffobj).as_string()
 
     def as_bibtex(self):
         return BibtexObject(self.cffobj).as_string()

--- a/src/cffconvert/lib/cff_1_1_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_1_x/biblatex.py
@@ -40,3 +40,8 @@ class BiblatexObject(Shared):
         if "date-released" in self.cffobj.keys():
             self.year = "year = {" + str(self.cffobj["date-released"].year) + "}"
         return self
+
+    def add_date(self):
+        if "date-released" in self.cffobj.keys():
+            self.date = "date = {" + self.cffobj["date-released"].isoformat() + "}"
+        return self

--- a/src/cffconvert/lib/cff_1_1_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_1_x/biblatex.py
@@ -1,0 +1,42 @@
+from cffconvert.lib.cff_1_x_x.authors.biblatex import BiblatexAuthor
+from cffconvert.lib.cff_1_x_x.biblatex import BiblatexObjectShared as Shared
+from cffconvert.lib.cff_1_x_x.urls.biblatex import BiblatexUrl
+
+
+class BiblatexObject(Shared):
+
+    supported_cff_versions = [
+        "1.1.0"
+    ]
+
+    def add_author(self):
+        authors_cff = self.cffobj.get("authors", [])
+        authors_biblatex = [BiblatexAuthor(a).as_string() for a in authors_cff]
+        authors_biblatex_filtered = [a for a in authors_biblatex if a is not None]
+        self.author = "author = {" + " and ".join(authors_biblatex_filtered) + "}"
+        return self
+
+    def add_doi(self):
+        if "doi" in self.cffobj.keys():
+            self.doi = "doi = {" + self.cffobj["doi"] + "}"
+        if "identifiers" in self.cffobj.keys():
+            identifiers = self.cffobj["identifiers"]
+            for identifier in identifiers:
+                if identifier["type"] == "doi":
+                    self.doi = "doi = {" + identifier["value"] + "}"
+                    break
+        return self
+
+    def add_month(self):
+        if "date-released" in self.cffobj.keys():
+            self.month = "month = {" + str(self.cffobj["date-released"].month) + "}"
+        return self
+
+    def add_url(self):
+        self.url = BiblatexUrl(self.cffobj).as_string()
+        return self
+
+    def add_year(self):
+        if "date-released" in self.cffobj.keys():
+            self.year = "year = {" + str(self.cffobj["date-released"].year) + "}"
+        return self

--- a/src/cffconvert/lib/cff_1_1_x/citation.py
+++ b/src/cffconvert/lib/cff_1_1_x/citation.py
@@ -3,6 +3,7 @@ from pykwalify.core import Core
 from ruamel.yaml import SafeConstructor
 from ruamel.yaml import YAML
 from cffconvert.lib.cff_1_1_x.apalike import ApalikeObject
+from cffconvert.lib.cff_1_1_x.biblatex import BiblatexObject
 from cffconvert.lib.cff_1_1_x.bibtex import BibtexObject
 from cffconvert.lib.cff_1_1_x.codemeta import CodemetaObject
 from cffconvert.lib.cff_1_1_x.endnote import EndnoteObject
@@ -54,6 +55,9 @@ class Citation_1_1_x(Contract):  # noqa
 
     def as_apalike(self):
         return ApalikeObject(self.cffobj).as_string()
+
+    def as_biblatex(self):
+        return BiblatexObject(self.cffobj).as_string()
 
     def as_bibtex(self):
         return BibtexObject(self.cffobj).as_string()

--- a/src/cffconvert/lib/cff_1_2_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_2_x/biblatex.py
@@ -41,3 +41,8 @@ class BiblatexObject(Shared):
         if "date-released" in self.cffobj.keys():
             self.year = "year = {" + self.cffobj["date-released"][:4] + "}"
         return self
+
+    def add_date(self):
+        if "date-released" in self.cffobj.keys():
+            self.date = "date = {" + self.cffobj["date-released"] + "}"
+        return self

--- a/src/cffconvert/lib/cff_1_2_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_2_x/biblatex.py
@@ -1,0 +1,43 @@
+from cffconvert.lib.cff_1_x_x.authors.biblatex import BiblatexAuthor
+from cffconvert.lib.cff_1_x_x.biblatex import BiblatexObjectShared as Shared
+from cffconvert.lib.cff_1_x_x.urls.biblatex import BiblatexUrl
+
+
+class BiblatexObject(Shared):
+
+    supported_cff_versions = [
+        "1.2.0"
+    ]
+
+    def add_author(self):
+        authors_cff = self.cffobj.get("authors", [])
+        authors_biblatex = [BiblatexAuthor(a).as_string() for a in authors_cff]
+        authors_biblatex_filtered = [a for a in authors_biblatex if a is not None]
+        self.author = "author = {" + " and ".join(authors_biblatex_filtered) + "}"
+        return self
+
+    def add_doi(self):
+        if "doi" in self.cffobj.keys():
+            self.doi = "doi = {" + self.cffobj["doi"] + "}"
+        if "identifiers" in self.cffobj.keys():
+            identifiers = self.cffobj["identifiers"]
+            for identifier in identifiers:
+                if identifier["type"] == "doi":
+                    self.doi = "doi = {" + identifier["value"] + "}"
+                    break
+        return self
+
+    def add_month(self):
+        if "date-released" in self.cffobj.keys():
+            month = self.cffobj["date-released"].split("-")[1].lstrip("0")
+            self.month = "month = {" + month + "}"
+        return self
+
+    def add_url(self):
+        self.url = BiblatexUrl(self.cffobj).as_string()
+        return self
+
+    def add_year(self):
+        if "date-released" in self.cffobj.keys():
+            self.year = "year = {" + self.cffobj["date-released"][:4] + "}"
+        return self

--- a/src/cffconvert/lib/cff_1_2_x/citation.py
+++ b/src/cffconvert/lib/cff_1_2_x/citation.py
@@ -5,6 +5,7 @@ from jsonschema.exceptions import ValidationError
 from ruamel.yaml import SafeConstructor
 from ruamel.yaml import YAML
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
+from cffconvert.lib.cff_1_2_x.biblatex import BiblatexObject
 from cffconvert.lib.cff_1_2_x.bibtex import BibtexObject
 from cffconvert.lib.cff_1_2_x.codemeta import CodemetaObject
 from cffconvert.lib.cff_1_2_x.endnote import EndnoteObject
@@ -56,6 +57,9 @@ class Citation_1_2_x(Contract):  # noqa
 
     def as_apalike(self):
         return ApalikeObject(self.cffobj).as_string()
+
+    def as_biblatex(self):
+        return BiblatexObject(self.cffobj).as_string()
 
     def as_bibtex(self):
         return BibtexObject(self.cffobj).as_string()

--- a/src/cffconvert/lib/cff_1_3_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_3_x/biblatex.py
@@ -41,3 +41,8 @@ class BiblatexObject(Shared):
         if "date-released" in self.cffobj.keys():
             self.year = "year = {" + self.cffobj["date-released"][:4] + "}"
         return self
+
+    def add_date(self):
+        if "date-released" in self.cffobj.keys():
+            self.date = "date = {" + self.cffobj["date-released"] + "}"
+        return self

--- a/src/cffconvert/lib/cff_1_3_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_3_x/biblatex.py
@@ -1,0 +1,43 @@
+from cffconvert.lib.cff_1_x_x.authors.biblatex import BiblatexAuthor
+from cffconvert.lib.cff_1_x_x.biblatex import BiblatexObjectShared as Shared
+from cffconvert.lib.cff_1_x_x.urls.biblatex import BiblatexUrl
+
+
+class BiblatexObject(Shared):
+
+    supported_cff_versions = [
+        "1.3.0"
+    ]
+
+    def add_author(self):
+        authors_cff = self.cffobj.get("authors", [])
+        authors_biblatex = [BiblatexAuthor(a).as_string() for a in authors_cff]
+        authors_biblatex_filtered = [a for a in authors_biblatex if a is not None]
+        self.author = "author = {" + " and ".join(authors_biblatex_filtered) + "}"
+        return self
+
+    def add_doi(self):
+        if "doi" in self.cffobj.keys():
+            self.doi = "doi = {" + self.cffobj["doi"] + "}"
+        if "identifiers" in self.cffobj.keys():
+            identifiers = self.cffobj["identifiers"]
+            for identifier in identifiers:
+                if identifier["type"] == "doi":
+                    self.doi = "doi = {" + identifier["value"] + "}"
+                    break
+        return self
+
+    def add_month(self):
+        if "date-released" in self.cffobj.keys():
+            month = self.cffobj["date-released"].split("-")[1].lstrip("0")
+            self.month = "month = {" + month + "}"
+        return self
+
+    def add_url(self):
+        self.url = BiblatexUrl(self.cffobj).as_string()
+        return self
+
+    def add_year(self):
+        if "date-released" in self.cffobj.keys():
+            self.year = "year = {" + self.cffobj["date-released"][:4] + "}"
+        return self

--- a/src/cffconvert/lib/cff_1_3_x/citation.py
+++ b/src/cffconvert/lib/cff_1_3_x/citation.py
@@ -5,6 +5,7 @@ from jsonschema.exceptions import ValidationError
 from ruamel.yaml import SafeConstructor
 from ruamel.yaml import YAML
 from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
+from cffconvert.lib.cff_1_3_x.biblatex import BiblatexObject
 from cffconvert.lib.cff_1_3_x.bibtex import BibtexObject
 from cffconvert.lib.cff_1_3_x.codemeta import CodemetaObject
 from cffconvert.lib.cff_1_3_x.endnote import EndnoteObject
@@ -56,6 +57,9 @@ class Citation_1_3_x(Contract):  # noqa
 
     def as_apalike(self):
         return ApalikeObject(self.cffobj).as_string()
+
+    def as_biblatex(self):
+        return BiblatexObject(self.cffobj).as_string()
 
     def as_bibtex(self):
         return BibtexObject(self.cffobj).as_string()

--- a/src/cffconvert/lib/cff_1_x_x/authors/biblatex.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/biblatex.py
@@ -2,7 +2,7 @@ from cffconvert.lib.cff_1_x_x.authors.base import BaseAuthor
 
 
 # pylint: disable=too-few-public-methods
-class BibtexAuthor(BaseAuthor):
+class BiblatexAuthor(BaseAuthor):
 
     def __init__(self, author):
         super().__init__(author)

--- a/src/cffconvert/lib/cff_1_x_x/authors/bibtex.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/bibtex.py
@@ -127,14 +127,14 @@ class BibtexAuthor(BaseAuthor):
             "___N_O_": self._from_name,
             "___N__E": self._from_name,
             "___N___": self._from_name,
-            "____AOE": BiblatexAuthor._from_thin_air,
-            "____AO_": BiblatexAuthor._from_thin_air,
-            "____A_E": BiblatexAuthor._from_thin_air,
-            "____A__": BiblatexAuthor._from_thin_air,
-            "_____OE": BiblatexAuthor._from_thin_air,
-            "_____O_": BiblatexAuthor._from_thin_air,
-            "______E": BiblatexAuthor._from_thin_air,
-            "_______": BiblatexAuthor._from_thin_air
+            "____AOE": BibtexAuthor._from_thin_air,
+            "____AO_": BibtexAuthor._from_thin_air,
+            "____A_E": BibtexAuthor._from_thin_air,
+            "____A__": BibtexAuthor._from_thin_air,
+            "_____OE": BibtexAuthor._from_thin_air,
+            "_____O_": BibtexAuthor._from_thin_air,
+            "______E": BibtexAuthor._from_thin_air,
+            "_______": BibtexAuthor._from_thin_air
         }
 
     def _from_alias(self):

--- a/src/cffconvert/lib/cff_1_x_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_x_x/biblatex.py
@@ -103,6 +103,8 @@ class BiblatexObjectShared:
         pass
 
     def add_repository(self):
+        if "repository-code" in self.cffobj.keys():
+            self.repository = "repository = {" + self.cffobj["repository-code"] + "}"
         if "repository" in self.cffobj.keys():
             self.repository = "repository = {" + self.cffobj["repository"] + "}"
         return self

--- a/src/cffconvert/lib/cff_1_x_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_x_x/biblatex.py
@@ -13,6 +13,16 @@ class BiblatexObjectShared:
         self.title = None
         self.url = None
         self.year = None
+        # below are new added fields not supported by bibtex
+        self.abstract = None
+        self.date = None
+        self.repository = None
+        self.license = None
+        self.version = None
+        self.institution = None
+        self.editor = None
+        self.swhid = None
+        self.keywords = None
         if initialize_empty:
             # clause for testing purposes
             pass
@@ -26,17 +36,36 @@ class BiblatexObjectShared:
                                    self.month,
                                    self.title,
                                    self.url,
-                                   self.year] if item is not None]
+                                   self.year,
+                                   self.abstract,
+                                   self.date,
+                                   self.repository,
+                                   self.license,
+                                   self.version,
+                                   self.institution,
+                                   self.editor,
+                                   self.swhid,
+                                   self.keywords] if item is not None]
         joined = ",\n".join(items)
-        return "@misc{YourReferenceHere,\n" + joined + "\n}\n"
+        return "@software{YourReferenceHere,\n" + joined + "\n}\n"
 
     def add_all(self):
-        self.add_author()   \
-            .add_doi()      \
-            .add_month()    \
-            .add_title()    \
-            .add_url()      \
-            .add_year()
+        self.add_author()     \
+            .add_doi()        \
+            .add_month()      \
+            .add_title()      \
+            .add_url()        \
+            .add_year()       \
+            .add_abstract()   \
+            .add_date()       \
+            .add_repository() \
+            .add_license()    \
+            .add_version()    \
+            .add_institution()\
+            .add_editor()     \
+            .add_swhid()      \
+            .add_keywords()
+
         return self
 
     @abstractmethod
@@ -63,6 +92,60 @@ class BiblatexObjectShared:
     @abstractmethod
     def add_year(self):
         pass
+
+    def add_abstract(self):
+        if "abstract" in self.cffobj.keys():
+            self.abstract = "abstract = {" + self.cffobj["abstract"] + "}"
+        return self
+
+    @abstractmethod
+    def add_date(self):
+        pass
+
+    def add_repository(self):
+        if "repository" in self.cffobj.keys():
+            self.repository = "repository = {" + self.cffobj["repository"] + "}"
+        return self
+
+    def add_license(self):
+        if "license" in self.cffobj.keys():
+            self.license = "license = {" + self.cffobj["license"] + "}"
+        return self
+
+    def add_version(self):
+        if "version" in self.cffobj.keys():
+            self.version = "version = {" + self.cffobj["version"] + "}"
+        return self
+
+    def add_institution(self):
+        if "contact" in self.cffobj.keys():
+            for contact in self.cffobj["contact"]:
+                if "name" in contact:
+                    self.institution = "institution = {" + contact["name"] + "}"
+                    break
+        return self
+
+    def add_editor(self):
+        if "contact" in self.cffobj.keys():
+            editors = [i["family-names"] + ", " + i["given-names"]
+                          for i in self.cffobj["contact"]
+                              if "name" not in i and "given-names" in i and "family-names" in i]
+            if editors:
+                self.editor = "editor = {" + " and ".join(editors) + "}"
+        return self
+
+    def add_swhid(self):
+        if "identifiers" in self.cffobj.keys():
+            for identifier in self.cffobj["identifiers"]:
+                if identifier["type"] == "swh":
+                    self.swhid = "swhid = {" + identifier["value"] + "}"
+                    break
+        return self
+
+    def add_keywords(self):
+        if "keywords" in self.cffobj.keys():
+            self.keywords = "keywords = {" + ", ".join(self.cffobj["keywords"]) + "}"
+        return self
 
     def as_string(self):
         return str(self)

--- a/src/cffconvert/lib/cff_1_x_x/biblatex.py
+++ b/src/cffconvert/lib/cff_1_x_x/biblatex.py
@@ -1,0 +1,76 @@
+from abc import abstractmethod
+
+
+class BiblatexObjectShared:
+
+    supported_cff_versions = None
+
+    def __init__(self, cffobj, initialize_empty=False):
+        self.cffobj = cffobj
+        self.author = None
+        self.doi = None
+        self.month = None
+        self.title = None
+        self.url = None
+        self.year = None
+        if initialize_empty:
+            # clause for testing purposes
+            pass
+        else:
+            self.check_cffobj()
+            self.add_all()
+
+    def __str__(self):
+        items = [item for item in [self.author,
+                                   self.doi,
+                                   self.month,
+                                   self.title,
+                                   self.url,
+                                   self.year] if item is not None]
+        joined = ",\n".join(items)
+        return "@misc{YourReferenceHere,\n" + joined + "\n}\n"
+
+    def add_all(self):
+        self.add_author()   \
+            .add_doi()      \
+            .add_month()    \
+            .add_title()    \
+            .add_url()      \
+            .add_year()
+        return self
+
+    @abstractmethod
+    def add_author(self):
+        pass
+
+    @abstractmethod
+    def add_doi(self):
+        pass
+
+    @abstractmethod
+    def add_month(self):
+        pass
+
+    def add_title(self):
+        if "title" in self.cffobj.keys():
+            self.title = "title = {" + self.cffobj["title"] + "}"
+        return self
+
+    @abstractmethod
+    def add_url(self):
+        pass
+
+    @abstractmethod
+    def add_year(self):
+        pass
+
+    def as_string(self):
+        return str(self)
+
+    def check_cffobj(self):
+        if not isinstance(self.cffobj, dict):
+            raise ValueError("Expected cffobj to be of type 'dict'.")
+        if "cff-version" not in self.cffobj.keys():
+            raise ValueError("Missing key 'cff-version' in CITATION.cff file.")
+        if self.cffobj["cff-version"] not in self.supported_cff_versions:
+            raise ValueError(f"cff-version: {self.cffobj['cff-version']} isn't a supported version.")

--- a/src/cffconvert/lib/cff_1_x_x/urls/biblatex.py
+++ b/src/cffconvert/lib/cff_1_x_x/urls/biblatex.py
@@ -1,0 +1,74 @@
+from cffconvert.lib.cff_1_x_x.urls.base import BaseUrl
+
+
+# pylint: disable=too-few-public-methods
+class BiblatexUrl(BaseUrl):
+
+    def __init__(self, cffobj):
+        super().__init__(cffobj)
+        self._behaviors = {
+            "IRACU": self._from_identifiers_url,
+            "IRAC_": self._from_identifiers_url,
+            "IRA_U": self._from_identifiers_url,
+            "IRA__": self._from_identifiers_url,
+            "IR_CU": self._from_identifiers_url,
+            "IR_C_": self._from_identifiers_url,
+            "IR__U": self._from_identifiers_url,
+            "IR___": self._from_identifiers_url,
+            "I_ACU": self._from_identifiers_url,
+            "I_AC_": self._from_identifiers_url,
+            "I_A_U": self._from_identifiers_url,
+            "I_A__": self._from_identifiers_url,
+            "I__CU": self._from_identifiers_url,
+            "I__C_": self._from_identifiers_url,
+            "I___U": self._from_identifiers_url,
+            "I____": self._from_identifiers_url,
+            "_RACU": self._from_url,
+            "_RAC_": self._from_repository_code,
+            "_RA_U": self._from_url,
+            "_RA__": self._from_repository,
+            "_R_CU": self._from_url,
+            "_R_C_": self._from_repository_code,
+            "_R__U": self._from_url,
+            "_R___": self._from_repository,
+            "__ACU": self._from_url,
+            "__AC_": self._from_repository_code,
+            "__A_U": self._from_url,
+            "__A__": self._from_repository_artifact,
+            "___CU": self._from_url,
+            "___C_": self._from_repository_code,
+            "____U": self._from_url,
+            "_____": BiblatexUrl._from_thin_air
+        }
+
+    def _from_identifiers_url(self):
+        urls = self._get_urls_from_identifiers()
+        if len(urls) > 0:
+            return f"url = { '{' + urls[0].get('value') + '}' }"
+        return None
+
+    def _from_repository(self):
+        return f"url = { '{' + self._cffobj.get('repository') + '}' }"
+
+    def _from_repository_artifact(self):
+        return f"url = { '{' + self._cffobj.get('repository-artifact') + '}' }"
+
+    def _from_repository_code(self):
+        return f"url = { '{' + self._cffobj.get('repository-code') + '}' }"
+
+    @staticmethod
+    def _from_thin_air():
+        return None
+
+    def _from_url(self):
+        return f"url = { '{' + self._cffobj.get('url') + '}' }"
+
+    def as_string(self):
+        key = "".join([
+            self._has_identifiers_url(),
+            self._has_repository(),
+            self._has_repository_artifact(),
+            self._has_repository_code(),
+            self._has_url()
+        ])
+        return self._behaviors[key]()

--- a/src/cffconvert/lib/contracts/citation.py
+++ b/src/cffconvert/lib/contracts/citation.py
@@ -17,6 +17,10 @@ class Contract(ABC):
         pass
 
     @abstractmethod
+    def as_biblatex(self):
+        pass
+
+    @abstractmethod
     def as_bibtex(self):
         pass
 

--- a/tests/cli/cff_1_0_3/biblatex.bib
+++ b/tests/cli/cff_1_0_3/biblatex.bib
@@ -1,0 +1,12 @@
+@software{YourReferenceHere,
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
+doi = {10.5281/zenodo.1162057},
+month = {1},
+title = {cffconvert},
+url = {https://github.com/citation-file-format/cffconvert},
+year = {2018},
+date = {2018-01-16},
+license = {Apache-2.0},
+version = {1.0.0},
+keywords = {citation, bibliography, cff, CITATION.cff}
+}

--- a/tests/cli/cff_1_1_0/biblatex.bib
+++ b/tests/cli/cff_1_1_0/biblatex.bib
@@ -1,0 +1,12 @@
+@software{YourReferenceHere,
+author = {Spaaks, Jurriaan H. and Klaver, Tom},
+doi = {10.5281/zenodo.1162057},
+month = {1},
+title = {cffconvert},
+url = {https://github.com/citation-file-format/cffconvert},
+year = {2018},
+date = {2018-01-16},
+license = {Apache-2.0},
+version = {1.0.0},
+keywords = {citation, bibliography, cff, CITATION.cff}
+}

--- a/tests/cli/cff_1_2_0/biblatex.bib
+++ b/tests/cli/cff_1_2_0/biblatex.bib
@@ -1,0 +1,5 @@
+@software{YourReferenceHere,
+author = {{Test author}},
+doi = {10.0000/from-doi},
+title = {Test title}
+}

--- a/tests/cli/cff_1_3_0/biblatex.bib
+++ b/tests/cli/cff_1_3_0/biblatex.bib
@@ -1,0 +1,5 @@
+@software{YourReferenceHere,
+author = {{Test author}},
+doi = {10.0000/from-doi},
+title = {Test title}
+}

--- a/tests/cli/helpers.py
+++ b/tests/cli/helpers.py
@@ -6,6 +6,7 @@ def get_formats():
     return [
         pytest.param("apalike", "apalike.txt", id="apalike", marks=pytest.mark.apalike),
         pytest.param("bibtex", "bibtex.bib", id="bibtex", marks=pytest.mark.bibtex),
+        pytest.param("biblatex", "biblatex.bib", id="biblatex", marks=pytest.mark.biblatex),
         pytest.param("cff", "CITATION.cff", id="cff"),
         pytest.param("codemeta", "codemeta.json", id="codemeta", marks=pytest.mark.codemeta),
         pytest.param("endnote", "endnote.enw", id="endnote", marks=pytest.mark.endnote),


### PR DESCRIPTION
This Pull-Request adds support for converting `CITATION.cff` to [biblatex-software](https://www.ctan.org/tex-archive/macros/latex/contrib/biblatex-contrib/biblatex-software) format adding the new `--format biblatex`, eg:

```sh
cffconvert -i CITATION.cff -f biblatex -o biblatex.bib
```

The Bibtex format `--format bibtex` was not changed, and the new format `--format biblatex` was added, the new format `biblatex` was build on top of the `bibtex` implementation, the source code of Bibtex was duplicated and modified to add the new fields below:

- abstract
-  date
-  repository
-  license
-  version
-  institution
-  editor
-  swhid
-  keywords

Important to mention that the fields `institution` and `editor` doesn't have a straight match with any field from CFF format, AFAIK. My approach was to collect it from the field `contact` from the `CITATION.cff`.

The `biblatex-software` documentation defines the field **institution** such as:
- "The institution(s) that took part in the software project"

I am not sure we have this kind of field on CITATION.cff, the strategy adopted here for the `institution` field is:

- Search for the `contact` field in CITATION.cff
  - If a `contact` field is found search for the 1st entry that matches the criteria below
    - The contact has the field `name` defined
  - Add it to the `institution` field 

The `biblatex-software` documentation defines the field **editor** such as:
- "The coordinator(s) of large modular software projects"

Again, I am not sure we have this kind of field on CITATION.cff, the strategy adopted here for the `editor` field is:

- Search for the `contact` field in CITATION.cff
  - If a `contact` field is found search for entries that matches the criteria below
    - The contact doesn't have the field `name`
    - The contact has the field `given-names` defined
    - The contact has the field `family-names` defined
  - Add `given-names` and  `family-names` of all contacts to the output

Below you can see how the results between `bibtex` and `biblatex` differs for the same input file.

### Example of use for the `bibtex` format

```sh
cffconvert -i tests/cli/cff_1_0_3/CITATION.cff -f bibtex
```
```bibtex
@misc{YourReferenceHere,
author = {Spaaks, Jurriaan H. and Klaver, Tom},
doi = {10.5281/zenodo.1162057},
month = {1},
title = {cffconvert},
url = {https://github.com/citation-file-format/cffconvert},
year = {2018}
}
```

### Example of use for the `biblatex` format

```sh
cffconvert -i tests/cli/cff_1_0_3/CITATION.cff -f biblatex
```
```bibtex
@software{YourReferenceHere,
author = {Spaaks, Jurriaan H. and Klaver, Tom},
doi = {10.5281/zenodo.1162057},
month = {1},
title = {cffconvert},
url = {https://github.com/citation-file-format/cffconvert},
year = {2018},
date = {2018-01-16},
repository = {https://github.com/citation-file-format/cffconvert},
license = {Apache-2.0},
version = {1.0.0},
keywords = {citation, bibliography, cff, CITATION.cff}
}
```

### Questions

I believe the code added by this PR is good but not good enough, I think I need some inputs from the more-experienced here about the compatibility between the CFF schema and the biblatex-software schema, specially for the fields **editor** and **institution**, the strategy that I've adopted is based on my experience using CITATION.cff to document some of my projects, where I have used the CITATION.cff `contact` field to describe who is the **institution** and the **editors** of the software project I am working on.

That said, I would like to ask: What do you think about the code proposed here, and about the strategy adopted for the fields I've mentioned?

Thanks for you time and your attention.

Closes: #152 