### PR TITLE
Formatting with latest ruff

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -8,7 +8,7 @@ repos:
         name: Validating CITATION.cff using 'cffconvert'
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.12.0
+    rev: 6.0.1
     hooks:
       - id: isort
         name: Sorting Python import lines using 'isort'
@@ -23,7 +23,7 @@ repos:
         name: Assessing the package metadata using 'pyroma'
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.0.278
+    rev: v0.11.11
     hooks:
       - id: ruff
         name: Linting using 'ruff'

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,7 +67,7 @@ dev = [
     "pre-commit",
     "prospector == 1.10.2",
     "pyroma == 4.2",
-    "ruff == 0.11.10"
+    "ruff == 0.11.11"
 ]
 gcloud = [
     "flask"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,11 +63,11 @@ Repository = "https://github.com/citation-file-format/cffconvert"
 [project.optional-dependencies]
 dev = [
     "build",
-    "isort == 5.12.0",
+    "isort == 6.0.1",
     "pre-commit",
     "prospector == 1.10.2",
     "pyroma == 4.2",
-    "ruff == 0.0.278"
+    "ruff == 0.11.10"
 ]
 gcloud = [
     "flask"
@@ -132,10 +132,10 @@ testpaths = [
 
 [tool.ruff]
 line-length = 120
-select = ["E", "F", "W", "C901", "Q"]
+lint.select = ["E", "F", "W", "C901", "Q"]
 
 # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # # #
 
-[tool.ruff.flake8-quotes]
+[tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"
 inline-quotes = "double"

--- a/src/cffconvert/__init__.py
+++ b/src/cffconvert/__init__.py
@@ -1,6 +1,4 @@
 from cffconvert.lib.citation import Citation
 
 
-__all__ = [
-    "Citation"
-]
+__all__ = ["Citation"]

--- a/src/cffconvert/cli/cli.py
+++ b/src/cffconvert/cli/cli.py
@@ -10,60 +10,21 @@ options = {
     "infile": {
         "type": click.Path(),
         "default": None,
-        "help": "Path to the CITATION.cff input file. If this option is omitted" +
-                f", '.{os.sep}CITATION.cff' is used."
+        "help": "Path to the CITATION.cff input file. If this option is omitted"
+        + f", '.{os.sep}CITATION.cff' is used.",
     },
-    "outfile": {
-        "type": click.Path(),
-        "default": None,
-        "help": "Path to the output file."
-    },
+    "outfile": {"type": click.Path(), "default": None, "help": "Path to the output file."},
     "outputformat": {
-        "type": click.Choice([
-            "apalike",
-            "bibtex",
-            "cff",
-            "codemeta",
-            "endnote",
-            "ris",
-            "schema.org",
-            "zenodo"
-        ]),
+        "type": click.Choice(["apalike", "bibtex", "cff", "codemeta", "endnote", "ris", "schema.org", "zenodo"]),
         "default": None,
-        "help": "Output format."
+        "help": "Output format.",
     },
-    "url": {
-        "type": str,
-        "default": None,
-        "help": "URL to the CITATION.cff input file."
-    },
-    "show_help": {
-        "is_flag": True,
-        "flag_value": True,
-        "default": False,
-        "help": "Show help and exit."
-    },
-    "show_trace": {
-        "is_flag": True,
-        "flag_value": True,
-        "default": False,
-        "help": "Show error trace."
-    },
-    "validate_only": {
-        "is_flag": True,
-        "default": False,
-        "help": "Validate the CITATION.cff file and exit."
-    },
-    "version": {
-        "is_flag": True,
-        "default": False,
-        "help": "Print version and exit."
-    },
-    "verbose": {
-        "is_flag": True,
-        "default": False,
-        "help": "Control output verbosity."
-    }
+    "url": {"type": str, "default": None, "help": "URL to the CITATION.cff input file."},
+    "show_help": {"is_flag": True, "flag_value": True, "default": False, "help": "Show help and exit."},
+    "show_trace": {"is_flag": True, "flag_value": True, "default": False, "help": "Show error trace."},
+    "validate_only": {"is_flag": True, "default": False, "help": "Validate the CITATION.cff file and exit."},
+    "version": {"is_flag": True, "default": False, "help": "Print version and exit."},
+    "verbose": {"is_flag": True, "default": False, "help": "Control output verbosity."},
 }
 epilog = """If this program is useful to you, consider giving it a star on GitHub:
 https://github.com/citation-file-format/cffconvert"""

--- a/src/cffconvert/cli/constants.py
+++ b/src/cffconvert/cli/constants.py
@@ -1,3 +1,1 @@
-GITHUB_API_VERSION_HEADER = {
-    "X-GitHub-Api-Version": "2022-11-28"
-}
+GITHUB_API_VERSION_HEADER = {"X-GitHub-Api-Version": "2022-11-28"}

--- a/src/cffconvert/cli/rawify_url.py
+++ b/src/cffconvert/cli/rawify_url.py
@@ -20,7 +20,7 @@ def rawify_url(url):
                 # Proceed with making the call without authenticating -- stricter rate limits apply
                 pass
             else:
-                headers.update({"Authorization": f"Bearer { token }"})
+                headers.update({"Authorization": f"Bearer {token}"})
 
             try:
                 response = requests.get(repos_api, headers=headers, timeout=10)

--- a/src/cffconvert/cli/read_from_url.py
+++ b/src/cffconvert/cli/read_from_url.py
@@ -15,7 +15,7 @@ def read_from_url(url):
         # Proceed with making the call without authenticating -- stricter rate limits apply
         pass
     else:
-        headers.update({"Authorization": f"Bearer { token }"})
+        headers.update({"Authorization": f"Bearer {token}"})
     response = requests.get(url_raw, headers=headers, timeout=30)
     if response.ok:
         return response.text

--- a/src/cffconvert/cli/validate_or_write_output.py
+++ b/src/cffconvert/cli/validate_or_write_output.py
@@ -32,7 +32,7 @@ def validate_or_write_output(outfile, outputformat, validate_only, citation, ver
             "endnote": citation.as_endnote,
             "ris": citation.as_ris,
             "schema.org": citation.as_schemaorg,
-            "zenodo": citation.as_zenodo
+            "zenodo": citation.as_zenodo,
         }[outputformat]()
         if outfile is None:
             print(outstr, end="")

--- a/src/cffconvert/gcloud/gcloud.py
+++ b/src/cffconvert/gcloud/gcloud.py
@@ -77,7 +77,7 @@ def cffconvert(request):
         "endnote": citation.as_endnote,
         "ris": citation.as_ris,
         "schema.org": citation.as_schemaorg,
-        "zenodo": citation.as_zenodo
+        "zenodo": citation.as_zenodo,
     }[outputformat]()
 
     return Response(outstr, mimetype=mimetype_plain)

--- a/src/cffconvert/lib/cff_1_0_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_0_x/apalike.py
@@ -4,12 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.apalike import ApalikeUrl
 
 
 class ApalikeObject(Shared):
-
-    supported_cff_versions = [
-        "1.0.1",
-        "1.0.2",
-        "1.0.3"
-    ]
+    supported_cff_versions = ["1.0.1", "1.0.2", "1.0.3"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_0_x/bibtex.py
+++ b/src/cffconvert/lib/cff_1_0_x/bibtex.py
@@ -4,12 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.bibtex import BibtexUrl
 
 
 class BibtexObject(Shared):
-
-    supported_cff_versions = [
-        "1.0.1",
-        "1.0.2",
-        "1.0.3"
-    ]
+    supported_cff_versions = ["1.0.1", "1.0.2", "1.0.3"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_0_x/citation.py
+++ b/src/cffconvert/lib/cff_1_0_x/citation.py
@@ -15,12 +15,7 @@ from cffconvert.root import get_package_root
 
 
 class Citation_1_0_x(Contract):  # noqa
-
-    supported_cff_versions = [
-        "1.0.1",
-        "1.0.2",
-        "1.0.3"
-    ]
+    supported_cff_versions = ["1.0.1", "1.0.2", "1.0.3"]
 
     def __init__(self, cffstr, cffversion):
         self.cffstr = cffstr

--- a/src/cffconvert/lib/cff_1_0_x/codemeta.py
+++ b/src/cffconvert/lib/cff_1_0_x/codemeta.py
@@ -2,6 +2,5 @@ from cffconvert.lib.cff_1_0_x.schemaorg import SchemaorgObject
 
 
 class CodemetaObject(SchemaorgObject):
-
     def __init__(self, cffobj, context="https://doi.org/10.5063/schema/codemeta-2.0", initialize_empty=False):
         super().__init__(cffobj, context=context, initialize_empty=initialize_empty)

--- a/src/cffconvert/lib/cff_1_0_x/endnote.py
+++ b/src/cffconvert/lib/cff_1_0_x/endnote.py
@@ -4,12 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.endnote import EndnoteUrl
 
 
 class EndnoteObject(Shared):
-
-    supported_cff_versions = [
-        "1.0.1",
-        "1.0.2",
-        "1.0.3"
-    ]
+    supported_cff_versions = ["1.0.1", "1.0.2", "1.0.3"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_0_x/ris.py
+++ b/src/cffconvert/lib/cff_1_0_x/ris.py
@@ -4,12 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.ris import RisUrl
 
 
 class RisObject(Shared):
-
-    supported_cff_versions = [
-        "1.0.1",
-        "1.0.2",
-        "1.0.3"
-    ]
+    supported_cff_versions = ["1.0.1", "1.0.2", "1.0.3"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_0_x/schemaorg.py
+++ b/src/cffconvert/lib/cff_1_0_x/schemaorg.py
@@ -4,12 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.schemaorg import SchemaorgUrls
 
 
 class SchemaorgObject(Shared):
-
-    supported_cff_versions = [
-        "1.0.1",
-        "1.0.2",
-        "1.0.3"
-    ]
+    supported_cff_versions = ["1.0.1", "1.0.2", "1.0.3"]
 
     def __init__(self, cffobj, context="https://schema.org", initialize_empty=False):
         super().__init__(cffobj)

--- a/src/cffconvert/lib/cff_1_0_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_0_x/zenodo.py
@@ -3,12 +3,7 @@ from cffconvert.lib.cff_1_x_x.zenodo import ZenodoObjectShared as Shared
 
 
 class ZenodoObject(Shared):
-
-    supported_cff_versions = [
-        "1.0.1",
-        "1.0.2",
-        "1.0.3"
-    ]
+    supported_cff_versions = ["1.0.1", "1.0.2", "1.0.3"]
 
     def add_contributors(self):
         # contributors doesn't exist in CFF v1.0.x

--- a/src/cffconvert/lib/cff_1_1_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_1_x/apalike.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.apalike import ApalikeUrl
 
 
 class ApalikeObject(Shared):
-
-    supported_cff_versions = [
-        "1.1.0"
-    ]
+    supported_cff_versions = ["1.1.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_1_x/bibtex.py
+++ b/src/cffconvert/lib/cff_1_1_x/bibtex.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.bibtex import BibtexUrl
 
 
 class BibtexObject(Shared):
-
-    supported_cff_versions = [
-        "1.1.0"
-    ]
+    supported_cff_versions = ["1.1.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_1_x/citation.py
+++ b/src/cffconvert/lib/cff_1_1_x/citation.py
@@ -15,10 +15,7 @@ from cffconvert.root import get_package_root
 
 
 class Citation_1_1_x(Contract):  # noqa
-
-    supported_cff_versions = [
-        "1.1.0"
-    ]
+    supported_cff_versions = ["1.1.0"]
 
     def __init__(self, cffstr, cffversion):
         self.cffstr = cffstr

--- a/src/cffconvert/lib/cff_1_1_x/codemeta.py
+++ b/src/cffconvert/lib/cff_1_1_x/codemeta.py
@@ -2,6 +2,5 @@ from cffconvert.lib.cff_1_1_x.schemaorg import SchemaorgObject
 
 
 class CodemetaObject(SchemaorgObject):
-
     def __init__(self, cffobj, context="https://doi.org/10.5063/schema/codemeta-2.0", initialize_empty=False):
         super().__init__(cffobj, context=context, initialize_empty=initialize_empty)

--- a/src/cffconvert/lib/cff_1_1_x/endnote.py
+++ b/src/cffconvert/lib/cff_1_1_x/endnote.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.endnote import EndnoteUrl
 
 
 class EndnoteObject(Shared):
-
-    supported_cff_versions = [
-        "1.1.0"
-    ]
+    supported_cff_versions = ["1.1.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_1_x/ris.py
+++ b/src/cffconvert/lib/cff_1_1_x/ris.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.ris import RisUrl
 
 
 class RisObject(Shared):
-
-    supported_cff_versions = [
-        "1.1.0"
-    ]
+    supported_cff_versions = ["1.1.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_1_x/schemaorg.py
+++ b/src/cffconvert/lib/cff_1_1_x/schemaorg.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.schemaorg import SchemaorgUrls
 
 
 class SchemaorgObject(Shared):
-
-    supported_cff_versions = [
-        "1.1.0"
-    ]
+    supported_cff_versions = ["1.1.0"]
 
     def __init__(self, cffobj, context="https://schema.org", initialize_empty=False):
         super().__init__(cffobj)

--- a/src/cffconvert/lib/cff_1_1_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_1_x/zenodo.py
@@ -3,10 +3,7 @@ from cffconvert.lib.cff_1_x_x.zenodo import ZenodoObjectShared as Shared
 
 
 class ZenodoObject(Shared):
-
-    supported_cff_versions = [
-        "1.1.0"
-    ]
+    supported_cff_versions = ["1.1.0"]
 
     def add_contributors(self):
         # contributors doesn't exist in CFF v1.1.x

--- a/src/cffconvert/lib/cff_1_2_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_2_x/apalike.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.apalike import ApalikeUrl
 
 
 class ApalikeObject(Shared):
-
-    supported_cff_versions = [
-        "1.2.0"
-    ]
+    supported_cff_versions = ["1.2.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_2_x/bibtex.py
+++ b/src/cffconvert/lib/cff_1_2_x/bibtex.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.bibtex import BibtexUrl
 
 
 class BibtexObject(Shared):
-
-    supported_cff_versions = [
-        "1.2.0"
-    ]
+    supported_cff_versions = ["1.2.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_2_x/citation.py
+++ b/src/cffconvert/lib/cff_1_2_x/citation.py
@@ -17,10 +17,7 @@ from cffconvert.root import get_package_root
 
 
 class Citation_1_2_x(Contract):  # noqa
-
-    supported_cff_versions = [
-        "1.2.0"
-    ]
+    supported_cff_versions = ["1.2.0"]
 
     def __init__(self, cffstr, cffversion):
         self.cffstr = cffstr
@@ -86,12 +83,9 @@ class Citation_1_2_x(Contract):  # noqa
             n_lines_max = 15
             is_long = len(error_lines) > n_lines_max
             if is_long and not verbose:
-                truncated_message = "\n".join([
-                    *error_lines[:n_lines_max],
-                    "",
-                    "...truncated output...",
-                    "Add --verbose flag for full output."
-                ])
+                truncated_message = "\n".join(
+                    [*error_lines[:n_lines_max], "", "...truncated output...", "Add --verbose flag for full output."]
+                )
                 # pylint:disable = raise-missing-from
                 raise ValidationError(truncated_message)
             raise

--- a/src/cffconvert/lib/cff_1_2_x/codemeta.py
+++ b/src/cffconvert/lib/cff_1_2_x/codemeta.py
@@ -2,6 +2,5 @@ from cffconvert.lib.cff_1_2_x.schemaorg import SchemaorgObject
 
 
 class CodemetaObject(SchemaorgObject):
-
     def __init__(self, cffobj, context="https://doi.org/10.5063/schema/codemeta-2.0", initialize_empty=False):
         super().__init__(cffobj, context=context, initialize_empty=initialize_empty)

--- a/src/cffconvert/lib/cff_1_2_x/endnote.py
+++ b/src/cffconvert/lib/cff_1_2_x/endnote.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.endnote import EndnoteUrl
 
 
 class EndnoteObject(Shared):
-
-    supported_cff_versions = [
-        "1.2.0"
-    ]
+    supported_cff_versions = ["1.2.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_2_x/ris.py
+++ b/src/cffconvert/lib/cff_1_2_x/ris.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.ris import RisUrl
 
 
 class RisObject(Shared):
-
-    supported_cff_versions = [
-        "1.2.0"
-    ]
+    supported_cff_versions = ["1.2.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_2_x/schemaorg.py
+++ b/src/cffconvert/lib/cff_1_2_x/schemaorg.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.schemaorg import SchemaorgUrls
 
 
 class SchemaorgObject(Shared):
-
-    supported_cff_versions = [
-        "1.2.0"
-    ]
+    supported_cff_versions = ["1.2.0"]
 
     def __init__(self, cffobj, context="https://schema.org", initialize_empty=False):
         super().__init__(cffobj)

--- a/src/cffconvert/lib/cff_1_2_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_2_x/zenodo.py
@@ -3,10 +3,7 @@ from cffconvert.lib.cff_1_x_x.zenodo import ZenodoObjectShared as Shared
 
 
 class ZenodoObject(Shared):
-
-    supported_cff_versions = [
-        "1.2.0"
-    ]
+    supported_cff_versions = ["1.2.0"]
 
     def add_contributors(self):
         # contributors doesn't exist in CFF v1.2.x

--- a/src/cffconvert/lib/cff_1_3_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_3_x/apalike.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.apalike import ApalikeUrl
 
 
 class ApalikeObject(Shared):
-
-    supported_cff_versions = [
-        "1.3.0"
-    ]
+    supported_cff_versions = ["1.3.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_3_x/bibtex.py
+++ b/src/cffconvert/lib/cff_1_3_x/bibtex.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.bibtex import BibtexUrl
 
 
 class BibtexObject(Shared):
-
-    supported_cff_versions = [
-        "1.3.0"
-    ]
+    supported_cff_versions = ["1.3.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_3_x/citation.py
+++ b/src/cffconvert/lib/cff_1_3_x/citation.py
@@ -17,10 +17,7 @@ from cffconvert.root import get_package_root
 
 
 class Citation_1_3_x(Contract):  # noqa
-
-    supported_cff_versions = [
-        "1.3.0"
-    ]
+    supported_cff_versions = ["1.3.0"]
 
     def __init__(self, cffstr, cffversion):
         self.cffstr = cffstr
@@ -86,12 +83,9 @@ class Citation_1_3_x(Contract):  # noqa
             n_lines_max = 15
             is_long = len(error_lines) > n_lines_max
             if is_long and not verbose:
-                truncated_message = "\n".join([
-                    *error_lines[:n_lines_max],
-                    "",
-                    "...truncated output...",
-                    "Add --verbose flag for full output."
-                ])
+                truncated_message = "\n".join(
+                    [*error_lines[:n_lines_max], "", "...truncated output...", "Add --verbose flag for full output."]
+                )
                 # pylint:disable = raise-missing-from
                 raise ValidationError(truncated_message)
             raise

--- a/src/cffconvert/lib/cff_1_3_x/codemeta.py
+++ b/src/cffconvert/lib/cff_1_3_x/codemeta.py
@@ -2,6 +2,5 @@ from cffconvert.lib.cff_1_3_x.schemaorg import SchemaorgObject
 
 
 class CodemetaObject(SchemaorgObject):
-
     def __init__(self, cffobj, context="https://doi.org/10.5063/schema/codemeta-2.0", initialize_empty=False):
         super().__init__(cffobj, context=context, initialize_empty=initialize_empty)

--- a/src/cffconvert/lib/cff_1_3_x/endnote.py
+++ b/src/cffconvert/lib/cff_1_3_x/endnote.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.endnote import EndnoteUrl
 
 
 class EndnoteObject(Shared):
-
-    supported_cff_versions = [
-        "1.3.0"
-    ]
+    supported_cff_versions = ["1.3.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_3_x/ris.py
+++ b/src/cffconvert/lib/cff_1_3_x/ris.py
@@ -4,10 +4,7 @@ from cffconvert.lib.cff_1_x_x.urls.ris import RisUrl
 
 
 class RisObject(Shared):
-
-    supported_cff_versions = [
-        "1.3.0"
-    ]
+    supported_cff_versions = ["1.3.0"]
 
     def add_author(self):
         authors_cff = self.cffobj.get("authors", [])

--- a/src/cffconvert/lib/cff_1_3_x/schemaorg.py
+++ b/src/cffconvert/lib/cff_1_3_x/schemaorg.py
@@ -5,10 +5,7 @@ from cffconvert.lib.cff_1_x_x.urls.schemaorg import SchemaorgUrls
 
 # pylint: disable=too-many-instance-attributes
 class SchemaorgObject(Shared):
-
-    supported_cff_versions = [
-        "1.3.0"
-    ]
+    supported_cff_versions = ["1.3.0"]
 
     def __init__(self, cffobj, context="https://schema.org", initialize_empty=False):
         super().__init__(cffobj)

--- a/src/cffconvert/lib/cff_1_3_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_3_x/zenodo.py
@@ -3,10 +3,7 @@ from cffconvert.lib.cff_1_x_x.zenodo import ZenodoObjectShared as Shared
 
 
 class ZenodoObject(Shared):
-
-    supported_cff_versions = [
-        "1.3.0"
-    ]
+    supported_cff_versions = ["1.3.0"]
 
     def add_contributors(self):
         contributors = []

--- a/src/cffconvert/lib/cff_1_x_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_x_x/apalike.py
@@ -14,7 +14,6 @@ from abc import abstractmethod
 
 
 class ApalikeObjectShared:
-
     supported_cff_versions = None
 
     def __init__(self, cffobj, initialize_empty=False):
@@ -33,21 +32,13 @@ class ApalikeObjectShared:
             self.add_all()
 
     def __str__(self):
-        items = [item for item in [self.author,
-                                   self.year,
-                                   self.title,
-                                   self.version,
-                                   self.doi,
-                                   self.url] if item is not None]
+        items = [
+            item for item in [self.author, self.year, self.title, self.version, self.doi, self.url] if item is not None
+        ]
         return " ".join(items) + "\n"
 
     def add_all(self):
-        self.add_author()   \
-            .add_year()     \
-            .add_title()    \
-            .add_version()  \
-            .add_doi()      \
-            .add_url()
+        self.add_author().add_year().add_title().add_version().add_doi().add_url()
         return self
 
     @abstractmethod

--- a/src/cffconvert/lib/cff_1_x_x/authors/apalike.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/apalike.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.authors.base import BaseAuthor
 
 # pylint: disable=too-few-public-methods
 class ApalikeAuthor(BaseAuthor):
-
     def __init__(self, author):
         super().__init__(author)
         self._behaviors = {
@@ -134,7 +133,7 @@ class ApalikeAuthor(BaseAuthor):
             "_____OE": ApalikeAuthor._from_thin_air,
             "_____O_": ApalikeAuthor._from_thin_air,
             "______E": ApalikeAuthor._from_thin_air,
-            "_______": ApalikeAuthor._from_thin_air
+            "_______": ApalikeAuthor._from_thin_air,
         }
 
     def _from_alias(self):

--- a/src/cffconvert/lib/cff_1_x_x/authors/base.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/base.py
@@ -3,7 +3,6 @@ from abc import ABC
 
 # pylint: disable=too-few-public-methods
 class BaseAuthor(ABC):
-
     def __init__(self, author):
         self._author = author
         self._behaviors = None
@@ -16,20 +15,22 @@ class BaseAuthor(ABC):
         nameparts = [
             self._author.get("name-particle"),
             self._author.get("family-names"),
-            self._author.get("name-suffix")
+            self._author.get("name-suffix"),
         ]
         return " ".join([n for n in nameparts if n is not None])
 
     def _get_key(self):
-        return "".join([
-            self._has_given_name(),
-            self._has_family_name(),
-            self._has_alias(),
-            self._has_name(),
-            self._has_affiliation(),
-            self._has_orcid(),
-            self._has_email()
-        ])
+        return "".join(
+            [
+                self._has_given_name(),
+                self._has_family_name(),
+                self._has_alias(),
+                self._has_name(),
+                self._has_affiliation(),
+                self._has_orcid(),
+                self._has_email(),
+            ]
+        )
 
     def _has_affiliation(self):
         value = self._author.get("affiliation", None)

--- a/src/cffconvert/lib/cff_1_x_x/authors/bibtex.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/bibtex.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.authors.base import BaseAuthor
 
 # pylint: disable=too-few-public-methods
 class BibtexAuthor(BaseAuthor):
-
     def __init__(self, author):
         super().__init__(author)
         self._behaviors = {
@@ -134,7 +133,7 @@ class BibtexAuthor(BaseAuthor):
             "_____OE": BibtexAuthor._from_thin_air,
             "_____O_": BibtexAuthor._from_thin_air,
             "______E": BibtexAuthor._from_thin_air,
-            "_______": BibtexAuthor._from_thin_air
+            "_______": BibtexAuthor._from_thin_air,
         }
 
     def _from_alias(self):
@@ -150,7 +149,7 @@ class BibtexAuthor(BaseAuthor):
         nameparts = [
             self._author.get("name-particle"),
             self._author.get("family-names"),
-            self._author.get("name-suffix")
+            self._author.get("name-suffix"),
         ]
         return " ".join([n for n in nameparts if n is not None])
 

--- a/src/cffconvert/lib/cff_1_x_x/authors/endnote.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/endnote.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.authors.base import BaseAuthor
 
 # pylint: disable=too-few-public-methods
 class EndnoteAuthor(BaseAuthor):
-
     def __init__(self, author):
         super().__init__(author)
         self._behaviors = {

--- a/src/cffconvert/lib/cff_1_x_x/authors/ris.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/ris.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.authors.base import BaseAuthor
 
 # pylint: disable=too-few-public-methods
 class RisAuthor(BaseAuthor):
-
     def __init__(self, author):
         super().__init__(author)
         self._behaviors = {
@@ -134,23 +133,23 @@ class RisAuthor(BaseAuthor):
             "_____OE": RisAuthor._from_thin_air,
             "_____O_": RisAuthor._from_thin_air,
             "______E": RisAuthor._from_thin_air,
-            "_______": RisAuthor._from_thin_air
+            "_______": RisAuthor._from_thin_air,
         }
 
     def _from_alias(self):
-        return f"AU  - { self._author.get('alias') }\n"
+        return f"AU  - {self._author.get('alias')}\n"
 
     def _from_given_and_last(self):
-        return f"AU  - { self._get_full_last_name() }, { self._author.get('given-names') }\n"
+        return f"AU  - {self._get_full_last_name()}, {self._author.get('given-names')}\n"
 
     def _from_given(self):
-        return f"AU  - { self._author.get('given-names') }\n"
+        return f"AU  - {self._author.get('given-names')}\n"
 
     def _from_last(self):
-        return f"AU  - { self._get_full_last_name() }\n"
+        return f"AU  - {self._get_full_last_name()}\n"
 
     def _from_name(self):
-        return f"AU  - { self._author.get('name') }\n"
+        return f"AU  - {self._author.get('name')}\n"
 
     def as_string(self):
         key = self._get_key()

--- a/src/cffconvert/lib/cff_1_x_x/authors/schemaorg.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/schemaorg.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.authors.base import BaseAuthor
 
 # pylint: disable=too-few-public-methods
 class SchemaorgAuthor(BaseAuthor):
-
     def __init__(self, author):
         super().__init__(author)
         self._behaviors = {
@@ -134,58 +133,42 @@ class SchemaorgAuthor(BaseAuthor):
             "_____OE": self._from_orcid_and_email,
             "_____O_": self._from_orcid,
             "______E": self._from_email,
-            "_______": SchemaorgAuthor._from_thin_air
+            "_______": SchemaorgAuthor._from_thin_air,
         }
 
     def _from_affiliation_and_email(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
-            "email": self._author.get("email")
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
+            "email": self._author.get("email"),
         }
 
     def _from_affiliation_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
-            "email": self._author.get("email")
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
+            "email": self._author.get("email"),
         }
 
     def _from_alias_and_email(self):
-        return {
-            "@type": "Person",
-            "alternateName": self._author.get("alias"),
-            "email": self._author.get("email")
-        }
+        return {"@type": "Person", "alternateName": self._author.get("alias"), "email": self._author.get("email")}
 
     def _from_alias_and_affiliation_and_email(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_alias_and_affiliation_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_alias_and_name_and_orcid_and_email(self):
@@ -194,7 +177,7 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Organization",
             "alternateName": self._author.get("alias"),
             "name": self._author.get("name"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_alias_and_name_and_email(self):
@@ -202,7 +185,7 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Organization",
             "alternateName": self._author.get("alias"),
             "name": self._author.get("name"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_alias_and_orcid_and_email(self):
@@ -210,43 +193,30 @@ class SchemaorgAuthor(BaseAuthor):
             "@id": self._author.get("orcid"),
             "@type": "Person",
             "alternateName": self._author.get("alias"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_email(self):
-        return {
-            "@type": "Person",
-            "email": self._author.get("email")
-        }
+        return {"@type": "Person", "email": self._author.get("email")}
 
     def _from_given_and_email(self):
-        return {
-            "@type": "Person",
-            "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
-        }
+        return {"@type": "Person", "givenName": self._author.get("given-names"), "email": self._author.get("email")}
 
     def _from_given_and_affiliation_and_email(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_affiliation_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_alias_and_email(self):
@@ -254,32 +224,26 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Person",
             "alternateName": self._author.get("alias"),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_alias_and_affiliation_and_email(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_alias_and_affiliation_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_alias_and_orcid_and_email(self):
@@ -288,7 +252,7 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Person",
             "alternateName": self._author.get("alias"),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_last_and_email(self):
@@ -296,32 +260,26 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Person",
             "familyName": self._get_full_last_name(),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_last_and_affiliation_and_email(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "familyName": self._get_full_last_name(),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_last_and_affiliation_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "familyName": self._get_full_last_name(),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_last_and_alias_and_email(self):
@@ -330,34 +288,28 @@ class SchemaorgAuthor(BaseAuthor):
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_last_and_alias_and_affiliation_and_email(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_last_and_alias_and_affiliation_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_last_and_alias_and_orcid_and_email(self):
@@ -367,7 +319,7 @@ class SchemaorgAuthor(BaseAuthor):
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_last_and_orcid_and_email(self):
@@ -376,7 +328,7 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Person",
             "familyName": self._get_full_last_name(),
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_given_and_orcid_and_email(self):
@@ -384,37 +336,27 @@ class SchemaorgAuthor(BaseAuthor):
             "@id": self._author.get("orcid"),
             "@type": "Person",
             "givenName": self._author.get("given-names"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_last_and_email(self):
-        return {
-            "@type": "Person",
-            "familyName": self._get_full_last_name(),
-            "email": self._author.get("email")
-        }
+        return {"@type": "Person", "familyName": self._get_full_last_name(), "email": self._author.get("email")}
 
     def _from_last_and_affiliation_and_email(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "familyName": self._get_full_last_name(),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_last_and_affiliation_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "familyName": self._get_full_last_name(),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_last_and_alias_and_email(self):
@@ -422,32 +364,26 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Person",
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_last_and_alias_and_affiliation_and_email(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_last_and_alias_and_affiliation_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_last_and_alias_and_orcid_and_email(self):
@@ -456,7 +392,7 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Person",
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_last_and_orcid_and_email(self):
@@ -464,63 +400,40 @@ class SchemaorgAuthor(BaseAuthor):
             "@id": self._author.get("orcid"),
             "@type": "Person",
             "familyName": self._get_full_last_name(),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_name_and_email(self):
-        return {
-            "@type": "Organization",
-            "name": self._author.get("name"),
-            "email": self._author.get("email")
-        }
+        return {"@type": "Organization", "name": self._author.get("name"), "email": self._author.get("email")}
 
     def _from_name_and_orcid_and_email(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Organization",
             "name": self._author.get("name"),
-            "email": self._author.get("email")
+            "email": self._author.get("email"),
         }
 
     def _from_orcid_and_email(self):
-        return {
-            "@id": self._author.get("orcid"),
-            "@type": "Person",
-            "email": self._author.get("email")
-        }
+        return {"@id": self._author.get("orcid"), "@type": "Person", "email": self._author.get("email")}
 
     def _from_affiliation(self):
-        return {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            }
-        }
+        return {"@type": "Person", "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")}}
 
     def _from_affiliation_and_orcid(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            }
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
         }
 
     def _from_alias(self):
-        return {
-            "@type": "Person",
-            "alternateName": self._author.get("alias")
-        }
+        return {"@type": "Person", "alternateName": self._author.get("alias")}
 
     def _from_alias_and_affiliation(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
         }
 
@@ -528,10 +441,7 @@ class SchemaorgAuthor(BaseAuthor):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
         }
 
@@ -540,78 +450,55 @@ class SchemaorgAuthor(BaseAuthor):
             "@id": self._author.get("orcid"),
             "@type": "Organization",
             "alternateName": self._author.get("alias"),
-            "name": self._author.get("name")
+            "name": self._author.get("name"),
         }
 
     def _from_alias_and_name(self):
-        return {
-            "@type": "Organization",
-            "alternateName": self._author.get("alias"),
-            "name": self._author.get("name")
-        }
+        return {"@type": "Organization", "alternateName": self._author.get("alias"), "name": self._author.get("name")}
 
     def _from_alias_and_orcid(self):
-        return {
-            "@id": self._author.get("orcid"),
-            "@type": "Person",
-            "alternateName": self._author.get("alias")
-        }
+        return {"@id": self._author.get("orcid"), "@type": "Person", "alternateName": self._author.get("alias")}
 
     def _from_given(self):
-        return {
-            "@type": "Person",
-            "givenName": self._author.get("given-names")
-        }
+        return {"@type": "Person", "givenName": self._author.get("given-names")}
 
     def _from_given_and_affiliation(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
-            "givenName": self._author.get("given-names")
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_affiliation_and_orcid(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
-            "givenName": self._author.get("given-names")
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_alias(self):
         return {
             "@type": "Person",
             "alternateName": self._author.get("alias"),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_alias_and_affiliation(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_alias_and_affiliation_and_orcid(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_alias_and_orcid(self):
@@ -619,37 +506,31 @@ class SchemaorgAuthor(BaseAuthor):
             "@id": self._author.get("orcid"),
             "@type": "Person",
             "alternateName": self._author.get("alias"),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_last(self):
         return {
             "@type": "Person",
             "familyName": self._get_full_last_name(),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_last_and_affiliation(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "familyName": self._get_full_last_name(),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_last_and_affiliation_and_orcid(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "familyName": self._get_full_last_name(),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_last_and_alias(self):
@@ -657,32 +538,26 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Person",
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_last_and_alias_and_affiliation(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_last_and_alias_and_affiliation_and_orcid(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_last_and_alias_and_orcid(self):
@@ -691,7 +566,7 @@ class SchemaorgAuthor(BaseAuthor):
             "@type": "Person",
             "alternateName": self._author.get("alias"),
             "familyName": self._get_full_last_name(),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_last_and_orcid(self):
@@ -699,71 +574,48 @@ class SchemaorgAuthor(BaseAuthor):
             "@id": self._author.get("orcid"),
             "@type": "Person",
             "familyName": self._get_full_last_name(),
-            "givenName": self._author.get("given-names")
+            "givenName": self._author.get("given-names"),
         }
 
     def _from_given_and_orcid(self):
-        return {
-            "@id": self._author.get("orcid"),
-            "@type": "Person",
-            "givenName": self._author.get("given-names")
-        }
+        return {"@id": self._author.get("orcid"), "@type": "Person", "givenName": self._author.get("given-names")}
 
     def _from_last(self):
-        return {
-            "@type": "Person",
-            "familyName": self._get_full_last_name()
-        }
+        return {"@type": "Person", "familyName": self._get_full_last_name()}
 
     def _from_last_and_affiliation(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
-            "familyName": self._get_full_last_name()
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
+            "familyName": self._get_full_last_name(),
         }
 
     def _from_last_and_affiliation_and_orcid(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
-            "familyName": self._get_full_last_name()
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
+            "familyName": self._get_full_last_name(),
         }
 
     def _from_last_and_alias(self):
-        return {
-            "@type": "Person",
-            "alternateName": self._author.get("alias"),
-            "familyName": self._get_full_last_name()
-        }
+        return {"@type": "Person", "alternateName": self._author.get("alias"), "familyName": self._get_full_last_name()}
 
     def _from_last_and_alias_and_affiliation(self):
         return {
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
-            "familyName": self._get_full_last_name()
+            "familyName": self._get_full_last_name(),
         }
 
     def _from_last_and_alias_and_affiliation_and_orcid(self):
         return {
             "@id": self._author.get("orcid"),
             "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": self._author.get("affiliation")
-            },
+            "affiliation": {"@type": "Organization", "name": self._author.get("affiliation")},
             "alternateName": self._author.get("alias"),
-            "familyName": self._get_full_last_name()
+            "familyName": self._get_full_last_name(),
         }
 
     def _from_last_and_alias_and_orcid(self):
@@ -771,34 +623,20 @@ class SchemaorgAuthor(BaseAuthor):
             "@id": self._author.get("orcid"),
             "@type": "Person",
             "alternateName": self._author.get("alias"),
-            "familyName": self._get_full_last_name()
+            "familyName": self._get_full_last_name(),
         }
 
     def _from_last_and_orcid(self):
-        return {
-            "@id": self._author.get("orcid"),
-            "@type": "Person",
-            "familyName": self._get_full_last_name()
-        }
+        return {"@id": self._author.get("orcid"), "@type": "Person", "familyName": self._get_full_last_name()}
 
     def _from_name(self):
-        return {
-            "@type": "Organization",
-            "name": self._author.get("name")
-        }
+        return {"@type": "Organization", "name": self._author.get("name")}
 
     def _from_name_and_orcid(self):
-        return {
-            "@id": self._author.get("orcid"),
-            "@type": "Organization",
-            "name": self._author.get("name")
-        }
+        return {"@id": self._author.get("orcid"), "@type": "Organization", "name": self._author.get("name")}
 
     def _from_orcid(self):
-        return {
-            "@id": self._author.get("orcid"),
-            "@type": "Person"
-        }
+        return {"@id": self._author.get("orcid"), "@type": "Person"}
 
     def as_dict(self):
         key = self._get_key()

--- a/src/cffconvert/lib/cff_1_x_x/authors/zenodo.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/zenodo.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.authors.base import BaseAuthor
 
 # pylint: disable=too-few-public-methods
 class ZenodoAuthor(BaseAuthor):
-
     def __init__(self, author):
         super().__init__(author)
         self._behaviors = {
@@ -134,144 +133,103 @@ class ZenodoAuthor(BaseAuthor):
             "_____OE": self._from_orcid,
             "_____O_": self._from_orcid,
             "______E": ZenodoAuthor._from_thin_air,
-            "_______": ZenodoAuthor._from_thin_air
+            "_______": ZenodoAuthor._from_thin_air,
         }
 
     def _from_affiliation(self):
-        return {
-            "affiliation": self._author.get("affiliation")
-        }
+        return {"affiliation": self._author.get("affiliation")}
 
     def _from_affiliation_and_orcid(self):
-        return {
-            "affiliation": self._author.get("affiliation"),
-            "orcid": self._get_id_from_orcid_url()
-        }
+        return {"affiliation": self._author.get("affiliation"), "orcid": self._get_id_from_orcid_url()}
 
     def _from_alias(self):
-        return {
-            "name": self._author.get("alias")
-        }
+        return {"name": self._author.get("alias")}
 
     def _from_alias_and_affiliation(self):
-        return {
-            "affiliation": self._author.get("affiliation"),
-            "name": self._author.get("alias")
-        }
+        return {"affiliation": self._author.get("affiliation"), "name": self._author.get("alias")}
 
     def _from_alias_and_affiliation_and_orcid(self):
         return {
             "affiliation": self._author.get("affiliation"),
             "name": self._author.get("alias"),
-            "orcid": self._get_id_from_orcid_url()
+            "orcid": self._get_id_from_orcid_url(),
         }
 
     def _from_alias_and_orcid(self):
-        return {
-            "name": self._author.get("alias"),
-            "orcid": self._get_id_from_orcid_url()
-        }
+        return {"name": self._author.get("alias"), "orcid": self._get_id_from_orcid_url()}
 
     def _from_given(self):
-        return {
-            "name": self._author.get("given-names")
-        }
+        return {"name": self._author.get("given-names")}
 
     def _from_given_and_affiliation(self):
-        return {
-            "affiliation": self._author.get("affiliation"),
-            "name": self._author.get("given-names")
-        }
+        return {"affiliation": self._author.get("affiliation"), "name": self._author.get("given-names")}
 
     def _from_given_and_affiliation_and_orcid(self):
         return {
             "affiliation": self._author.get("affiliation"),
             "name": self._author.get("given-names"),
-            "orcid": self._get_id_from_orcid_url()
+            "orcid": self._get_id_from_orcid_url(),
         }
 
     def _from_given_and_last(self):
-        return {
-            "name": self._get_full_last_name() + ", " + self._author.get("given-names")
-        }
+        return {"name": self._get_full_last_name() + ", " + self._author.get("given-names")}
 
     def _from_given_and_last_and_affiliation(self):
         return {
             "affiliation": self._author.get("affiliation"),
-            "name": self._get_full_last_name() + ", " + self._author.get("given-names")
+            "name": self._get_full_last_name() + ", " + self._author.get("given-names"),
         }
 
     def _from_given_and_last_and_affiliation_and_orcid(self):
         return {
             "affiliation": self._author.get("affiliation"),
             "name": self._get_full_last_name() + ", " + self._author.get("given-names"),
-            "orcid": self._get_id_from_orcid_url()
+            "orcid": self._get_id_from_orcid_url(),
         }
 
     def _from_given_and_last_and_orcid(self):
         return {
             "name": self._get_full_last_name() + ", " + self._author.get("given-names"),
-            "orcid": self._get_id_from_orcid_url()
+            "orcid": self._get_id_from_orcid_url(),
         }
 
     def _from_given_and_orcid(self):
-        return {
-            "name": self._author.get("given-names"),
-            "orcid": self._get_id_from_orcid_url()
-        }
+        return {"name": self._author.get("given-names"), "orcid": self._get_id_from_orcid_url()}
 
     def _from_last(self):
-        return {
-            "name": self._get_full_last_name()
-        }
+        return {"name": self._get_full_last_name()}
 
     def _from_last_and_affiliation(self):
-        return {
-            "affiliation": self._author.get("affiliation"),
-            "name": self._get_full_last_name()
-        }
+        return {"affiliation": self._author.get("affiliation"), "name": self._get_full_last_name()}
 
     def _from_last_and_affiliation_and_orcid(self):
         return {
             "affiliation": self._author.get("affiliation"),
             "name": self._get_full_last_name(),
-            "orcid": self._get_id_from_orcid_url()
+            "orcid": self._get_id_from_orcid_url(),
         }
 
     def _from_last_and_orcid(self):
-        return {
-            "name": self._get_full_last_name(),
-            "orcid": self._get_id_from_orcid_url()
-        }
+        return {"name": self._get_full_last_name(), "orcid": self._get_id_from_orcid_url()}
 
     def _from_name(self):
-        return {
-            "name": self._author.get("name")
-        }
+        return {"name": self._author.get("name")}
 
     def _from_name_and_affiliation(self):
-        return {
-            "affiliation": self._author.get("affiliation"),
-            "name": self._author.get("name")
-        }
+        return {"affiliation": self._author.get("affiliation"), "name": self._author.get("name")}
 
     def _from_name_and_affiliation_and_orcid(self):
         return {
             "affiliation": self._author.get("affiliation"),
             "name": self._author.get("name"),
-            "orcid": self._get_id_from_orcid_url()
+            "orcid": self._get_id_from_orcid_url(),
         }
 
     def _from_name_and_orcid(self):
-        return {
-            "name": self._author.get("name"),
-            "orcid": self._get_id_from_orcid_url()
-        }
+        return {"name": self._author.get("name"), "orcid": self._get_id_from_orcid_url()}
 
     def _from_orcid(self):
-        return {
-            "orcid": self._get_id_from_orcid_url()
-        }
+        return {"orcid": self._get_id_from_orcid_url()}
 
     def _get_id_from_orcid_url(self):
         return self._author.get("orcid").replace("https://orcid.org/", "")

--- a/src/cffconvert/lib/cff_1_x_x/bibtex.py
+++ b/src/cffconvert/lib/cff_1_x_x/bibtex.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 
 
 class BibtexObjectShared:
-
     supported_cff_versions = None
 
     def __init__(self, cffobj, initialize_empty=False):
@@ -21,22 +20,14 @@ class BibtexObjectShared:
             self.add_all()
 
     def __str__(self):
-        items = [item for item in [self.author,
-                                   self.doi,
-                                   self.month,
-                                   self.title,
-                                   self.url,
-                                   self.year] if item is not None]
+        items = [
+            item for item in [self.author, self.doi, self.month, self.title, self.url, self.year] if item is not None
+        ]
         joined = ",\n".join(items)
         return "@misc{YourReferenceHere,\n" + joined + "\n}\n"
 
     def add_all(self):
-        self.add_author()   \
-            .add_doi()      \
-            .add_month()    \
-            .add_title()    \
-            .add_url()      \
-            .add_year()
+        self.add_author().add_doi().add_month().add_title().add_url().add_year()
         return self
 
     @abstractmethod

--- a/src/cffconvert/lib/cff_1_x_x/endnote.py
+++ b/src/cffconvert/lib/cff_1_x_x/endnote.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 
 
 class EndnoteObjectShared:
-
     supported_cff_versions = None
 
     def __init__(self, cffobj, initialize_empty=False):
@@ -21,21 +20,13 @@ class EndnoteObjectShared:
             self.add_all()
 
     def __str__(self):
-        items = [item for item in [self.author,
-                                   self.year,
-                                   self.keyword,
-                                   self.doi,
-                                   self.name,
-                                   self.url] if item is not None]
+        items = [
+            item for item in [self.author, self.year, self.keyword, self.doi, self.name, self.url] if item is not None
+        ]
         return "%0 Generic\n" + "".join(items)
 
     def add_all(self):
-        self.add_author() \
-            .add_doi() \
-            .add_keyword() \
-            .add_name() \
-            .add_url() \
-            .add_year()
+        self.add_author().add_doi().add_keyword().add_name().add_url().add_year()
         return self
 
     @abstractmethod

--- a/src/cffconvert/lib/cff_1_x_x/ris.py
+++ b/src/cffconvert/lib/cff_1_x_x/ris.py
@@ -2,7 +2,6 @@ from abc import abstractmethod
 
 
 class RisObjectShared:
-
     supported_cff_versions = None
 
     def __init__(self, cffobj, initialize_empty=False):
@@ -23,25 +22,24 @@ class RisObjectShared:
             self.add_all()
 
     def __str__(self):
-        items = [item for item in [self.abstract,
-                                   self.author,
-                                   self.date,
-                                   self.doi,
-                                   self.keywords,
-                                   self.year,
-                                   self.title,
-                                   self.url] if item is not None]
+        items = [
+            item
+            for item in [
+                self.abstract,
+                self.author,
+                self.date,
+                self.doi,
+                self.keywords,
+                self.year,
+                self.title,
+                self.url,
+            ]
+            if item is not None
+        ]
         return "TY  - GEN\n" + "".join(items) + "ER\n"
 
     def add_all(self):
-        self.add_abstract() \
-            .add_author()   \
-            .add_date()     \
-            .add_doi()      \
-            .add_keywords()  \
-            .add_title()    \
-            .add_url()      \
-            .add_year()
+        self.add_abstract().add_author().add_date().add_doi().add_keywords().add_title().add_url().add_year()
         return self
 
     def add_abstract(self):

--- a/src/cffconvert/lib/cff_1_x_x/schemaorg.py
+++ b/src/cffconvert/lib/cff_1_x_x/schemaorg.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class SchemaorgObjectShared:
-
     supported_cff_versions = None
 
     def __init__(self, cffobj):
@@ -36,23 +35,13 @@ class SchemaorgObjectShared:
             "license": self.license,
             "name": self.name,
             "url": self.url,
-            "version": self.version
+            "version": self.version,
         }
         filtered = [item for item in data.items() if item[1] is not None]
         return json.dumps(dict(filtered), sort_keys=sort_keys, indent=indent, ensure_ascii=False) + "\n"
 
     def add_all(self):
-        self.add_author()           \
-            .add_contributor()      \
-            .add_date_published()   \
-            .add_description()      \
-            .add_identifier()       \
-            .add_keywords()         \
-            .add_license()          \
-            .add_name()             \
-            .add_type()             \
-            .add_urls()             \
-            .add_version()
+        self.add_author().add_contributor().add_date_published().add_description().add_identifier().add_keywords().add_license().add_name().add_type().add_urls().add_version()
         return self
 
     @abstractmethod

--- a/src/cffconvert/lib/cff_1_x_x/urls/apalike.py
+++ b/src/cffconvert/lib/cff_1_x_x/urls/apalike.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.urls.base import BaseUrl
 
 # pylint: disable=too-few-public-methods
 class ApalikeUrl(BaseUrl):
-
     def __init__(self, cffobj):
         super().__init__(cffobj)
         self._behaviors = {
@@ -38,7 +37,7 @@ class ApalikeUrl(BaseUrl):
             "___CU": self._from_url,
             "___C_": self._from_repository_code,
             "____U": self._from_url,
-            "_____": ApalikeUrl._from_thin_air
+            "_____": ApalikeUrl._from_thin_air,
         }
 
     def _from_identifiers_url(self):
@@ -64,11 +63,13 @@ class ApalikeUrl(BaseUrl):
         return "URL: " + self._cffobj.get("url")
 
     def as_string(self):
-        key = "".join([
-            self._has_identifiers_url(),
-            self._has_repository(),
-            self._has_repository_artifact(),
-            self._has_repository_code(),
-            self._has_url()
-        ])
+        key = "".join(
+            [
+                self._has_identifiers_url(),
+                self._has_repository(),
+                self._has_repository_artifact(),
+                self._has_repository_code(),
+                self._has_url(),
+            ]
+        )
         return self._behaviors[key]()

--- a/src/cffconvert/lib/cff_1_x_x/urls/base.py
+++ b/src/cffconvert/lib/cff_1_x_x/urls/base.py
@@ -3,7 +3,6 @@ from abc import ABC
 
 # pylint: disable=too-few-public-methods
 class BaseUrl(ABC):
-
     def __init__(self, cffobj):
         self._cffobj = cffobj
         self._behaviors = None

--- a/src/cffconvert/lib/cff_1_x_x/urls/bibtex.py
+++ b/src/cffconvert/lib/cff_1_x_x/urls/bibtex.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.urls.base import BaseUrl
 
 # pylint: disable=too-few-public-methods
 class BibtexUrl(BaseUrl):
-
     def __init__(self, cffobj):
         super().__init__(cffobj)
         self._behaviors = {
@@ -38,37 +37,39 @@ class BibtexUrl(BaseUrl):
             "___CU": self._from_url,
             "___C_": self._from_repository_code,
             "____U": self._from_url,
-            "_____": BibtexUrl._from_thin_air
+            "_____": BibtexUrl._from_thin_air,
         }
 
     def _from_identifiers_url(self):
         urls = self._get_urls_from_identifiers()
         if len(urls) > 0:
-            return f"url = { '{' + urls[0].get('value') + '}' }"
+            return f"url = {'{' + urls[0].get('value') + '}'}"
         return None
 
     def _from_repository(self):
-        return f"url = { '{' + self._cffobj.get('repository') + '}' }"
+        return f"url = {'{' + self._cffobj.get('repository') + '}'}"
 
     def _from_repository_artifact(self):
-        return f"url = { '{' + self._cffobj.get('repository-artifact') + '}' }"
+        return f"url = {'{' + self._cffobj.get('repository-artifact') + '}'}"
 
     def _from_repository_code(self):
-        return f"url = { '{' + self._cffobj.get('repository-code') + '}' }"
+        return f"url = {'{' + self._cffobj.get('repository-code') + '}'}"
 
     @staticmethod
     def _from_thin_air():
         return None
 
     def _from_url(self):
-        return f"url = { '{' + self._cffobj.get('url') + '}' }"
+        return f"url = {'{' + self._cffobj.get('url') + '}'}"
 
     def as_string(self):
-        key = "".join([
-            self._has_identifiers_url(),
-            self._has_repository(),
-            self._has_repository_artifact(),
-            self._has_repository_code(),
-            self._has_url()
-        ])
+        key = "".join(
+            [
+                self._has_identifiers_url(),
+                self._has_repository(),
+                self._has_repository_artifact(),
+                self._has_repository_code(),
+                self._has_url(),
+            ]
+        )
         return self._behaviors[key]()

--- a/src/cffconvert/lib/cff_1_x_x/urls/endnote.py
+++ b/src/cffconvert/lib/cff_1_x_x/urls/endnote.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.urls.base import BaseUrl
 
 # pylint: disable=too-few-public-methods
 class EndnoteUrl(BaseUrl):
-
     def __init__(self, cffobj):
         super().__init__(cffobj)
         self._behaviors = {
@@ -38,7 +37,7 @@ class EndnoteUrl(BaseUrl):
             "___CU": self._from_url,
             "___C_": self._from_repository_code,
             "____U": self._from_url,
-            "_____": EndnoteUrl._from_thin_air
+            "_____": EndnoteUrl._from_thin_air,
         }
 
     def _from_identifiers_url(self):
@@ -64,11 +63,13 @@ class EndnoteUrl(BaseUrl):
         return "%U " + self._cffobj.get("url") + "\n"
 
     def as_string(self):
-        key = "".join([
-            self._has_identifiers_url(),
-            self._has_repository(),
-            self._has_repository_artifact(),
-            self._has_repository_code(),
-            self._has_url()
-        ])
+        key = "".join(
+            [
+                self._has_identifiers_url(),
+                self._has_repository(),
+                self._has_repository_artifact(),
+                self._has_repository_code(),
+                self._has_url(),
+            ]
+        )
         return self._behaviors[key]()

--- a/src/cffconvert/lib/cff_1_x_x/urls/ris.py
+++ b/src/cffconvert/lib/cff_1_x_x/urls/ris.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.urls.base import BaseUrl
 
 # pylint: disable=too-few-public-methods
 class RisUrl(BaseUrl):
-
     def __init__(self, cffobj):
         super().__init__(cffobj)
         self._behaviors = {
@@ -38,37 +37,39 @@ class RisUrl(BaseUrl):
             "___CU": self._from_url,
             "___C_": self._from_repository_code,
             "____U": self._from_url,
-            "_____": RisUrl._from_thin_air
+            "_____": RisUrl._from_thin_air,
         }
 
     def _from_identifiers_url(self):
         urls = self._get_urls_from_identifiers()
         if len(urls) > 0:
-            return f"UR  - { urls[0].get('value') }\n"
+            return f"UR  - {urls[0].get('value')}\n"
         return None
 
     def _from_repository(self):
-        return f"UR  - { self._cffobj.get('repository') }\n"
+        return f"UR  - {self._cffobj.get('repository')}\n"
 
     def _from_repository_artifact(self):
-        return f"UR  - { self._cffobj.get('repository-artifact') }\n"
+        return f"UR  - {self._cffobj.get('repository-artifact')}\n"
 
     def _from_repository_code(self):
-        return f"UR  - { self._cffobj.get('repository-code') }\n"
+        return f"UR  - {self._cffobj.get('repository-code')}\n"
 
     @staticmethod
     def _from_thin_air():
         return None
 
     def _from_url(self):
-        return f"UR  - { self._cffobj.get('url') }\n"
+        return f"UR  - {self._cffobj.get('url')}\n"
 
     def as_string(self):
-        key = "".join([
-            self._has_identifiers_url(),
-            self._has_repository(),
-            self._has_repository_artifact(),
-            self._has_repository_code(),
-            self._has_url()
-        ])
+        key = "".join(
+            [
+                self._has_identifiers_url(),
+                self._has_repository(),
+                self._has_repository_artifact(),
+                self._has_repository_code(),
+                self._has_url(),
+            ]
+        )
         return self._behaviors[key]()

--- a/src/cffconvert/lib/cff_1_x_x/urls/schemaorg.py
+++ b/src/cffconvert/lib/cff_1_x_x/urls/schemaorg.py
@@ -3,7 +3,6 @@ from cffconvert.lib.cff_1_x_x.urls.base import BaseUrl
 
 # pylint: disable=too-few-public-methods
 class SchemaorgUrls(BaseUrl):
-
     def __init__(self, cffobj):
         super().__init__(cffobj)
         self._behaviors = {
@@ -38,7 +37,7 @@ class SchemaorgUrls(BaseUrl):
             "___CU": self._from_repository_code_and_url,
             "___C_": self._from_repository_code,
             "____U": self._from_url,
-            "_____": SchemaorgUrls._from_thin_air
+            "_____": SchemaorgUrls._from_thin_air,
         }
 
     def _from_identifiers_url_and_repository_code(self):
@@ -85,11 +84,13 @@ class SchemaorgUrls(BaseUrl):
         return None, self._cffobj.get("url")
 
     def as_tuple(self):
-        key = "".join([
-            self._has_identifiers_url(),
-            self._has_repository(),
-            self._has_repository_artifact(),
-            self._has_repository_code(),
-            self._has_url()
-        ])
+        key = "".join(
+            [
+                self._has_identifiers_url(),
+                self._has_repository(),
+                self._has_repository_artifact(),
+                self._has_repository_code(),
+                self._has_url(),
+            ]
+        )
         return self._behaviors[key]()

--- a/src/cffconvert/lib/cff_1_x_x/zenodo.py
+++ b/src/cffconvert/lib/cff_1_x_x/zenodo.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class ZenodoObjectShared:
-
     supported_cff_versions = None
 
     def __init__(self, cffobj, initialize_empty=False):
@@ -36,22 +35,13 @@ class ZenodoObjectShared:
             "related_identifiers": self.related_identifiers,
             "title": self.title,
             "upload_type": self.upload_type,
-            "version": self.version
+            "version": self.version,
         }
         filtered = [item for item in data.items() if item[1] is not None]
         return json.dumps(dict(filtered), sort_keys=sort_keys, indent=indent, ensure_ascii=False) + "\n"
 
     def add_all(self):
-        self.add_contributors()        \
-            .add_creators()            \
-            .add_description()         \
-            .add_keywords()            \
-            .add_license()             \
-            .add_publication_date()    \
-            .add_related_identifiers() \
-            .add_title()               \
-            .add_upload_type()         \
-            .add_version()
+        self.add_contributors().add_creators().add_description().add_keywords().add_license().add_publication_date().add_related_identifiers().add_title().add_upload_type().add_version()
         return self
 
     @abstractmethod
@@ -87,7 +77,7 @@ class ZenodoObjectShared:
                 "IsMetadataFor",
                 "IsOriginalFormOf",
                 "IsVariantFormOf",
-                "IsVersionOf"
+                "IsVersionOf",
             ]
             return None if condition else rel[0].lower() + rel[1:]
 
@@ -99,11 +89,13 @@ class ZenodoObjectShared:
             if identifier.get("type") == "other" or identifier.get("value") in seen:
                 # identifier type unsupported or identifier value seen already
                 continue
-            related_identifiers.append({
-                "identifier": identifier.get("value"),
-                "relation": map_relation_type(identifier.get("relation")) or "isSupplementedBy",
-                "scheme": identifier.get("type")
-            })
+            related_identifiers.append(
+                {
+                    "identifier": identifier.get("value"),
+                    "relation": map_relation_type(identifier.get("relation")) or "isSupplementedBy",
+                    "scheme": identifier.get("type"),
+                }
+            )
             seen.append(identifier.get("value"))
         # add from doi
         doi = self.cffobj.get("doi")
@@ -111,11 +103,7 @@ class ZenodoObjectShared:
             # doi not available or seen already
             pass
         else:
-            related_identifiers.append({
-                "identifier": doi,
-                "relation": "isSupplementedBy",
-                "scheme": "doi"
-            })
+            related_identifiers.append({"identifier": doi, "relation": "isSupplementedBy", "scheme": "doi"})
             seen.append(doi)
         # add from url sources
         for cffkey in ["repository", "repository-artifact", "repository-code", "url"]:
@@ -123,11 +111,7 @@ class ZenodoObjectShared:
             if url is None or url in seen:
                 # url not available or seen already
                 continue
-            related_identifiers.append({
-                "identifier": url,
-                "relation": "isSupplementedBy",
-                "scheme": "url"
-            })
+            related_identifiers.append({"identifier": url, "relation": "isSupplementedBy", "scheme": "url"})
             seen.append(url)
         self.related_identifiers = related_identifiers if len(related_identifiers) > 0 else None
         return self

--- a/src/cffconvert/lib/citation.py
+++ b/src/cffconvert/lib/citation.py
@@ -6,14 +6,13 @@ from cffconvert.lib.cff_1_3_x.citation import Citation_1_3_x
 
 
 class Citation:
-
     _implementations = {
         "1.0.1": Citation_1_0_x,
         "1.0.2": Citation_1_0_x,
         "1.0.3": Citation_1_0_x,
         "1.1.0": Citation_1_1_x,
         "1.2.0": Citation_1_2_x,
-        "1.3.0": Citation_1_3_x
+        "1.3.0": Citation_1_3_x,
     }
     supported_cff_versions = _implementations.keys()
 

--- a/src/cffconvert/lib/contracts/citation.py
+++ b/src/cffconvert/lib/contracts/citation.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class Contract(ABC):
-
     @abstractmethod
     def _get_schema(self):
         pass

--- a/tests/cli/helpers.py
+++ b/tests/cli/helpers.py
@@ -11,7 +11,7 @@ def get_formats():
         pytest.param("endnote", "endnote.enw", id="endnote", marks=pytest.mark.endnote),
         pytest.param("ris", "ris.txt", id="ris", marks=pytest.mark.ris),
         pytest.param("schema.org", "schemaorg.json", id="schema.org", marks=pytest.mark.schemaorg),
-        pytest.param("zenodo", ".zenodo.json", id="zenodo", marks=pytest.mark.zenodo)
+        pytest.param("zenodo", ".zenodo.json", id="zenodo", marks=pytest.mark.zenodo),
     ]
 
 

--- a/tests/cli/test_rawify_url.py
+++ b/tests/cli/test_rawify_url.py
@@ -26,8 +26,12 @@ def test_github_url_with_owner_repo_blob_branchname_filename():
 
 @pytest.mark.cli
 def test_github_url_with_owner_repo_blob_branchname_filename_deep():
-    actual = rawify_url("https://github.com/theownername/thereponame/blob/thebranchname/somedir/someotherdir/thefilename")
-    expected = "https://raw.githubusercontent.com/theownername/thereponame/thebranchname/somedir/someotherdir/thefilename"
+    actual = rawify_url(
+        "https://github.com/theownername/thereponame/blob/thebranchname/somedir/someotherdir/thefilename"
+    )
+    expected = (
+        "https://raw.githubusercontent.com/theownername/thereponame/thebranchname/somedir/someotherdir/thefilename"
+    )
     assert actual == expected
 
 
@@ -40,7 +44,9 @@ def test_github_url_with_owner_repo_blob_sha():
 
 @pytest.mark.cli
 def test_github_url_with_owner_repo_blob_sha_filename():
-    actual = rawify_url("https://github.com/theownername/thereponame/blob/0123456789abcdef0123456789abcdef01234567/thefilename")
+    actual = rawify_url(
+        "https://github.com/theownername/thereponame/blob/0123456789abcdef0123456789abcdef01234567/thefilename"
+    )
     expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/thefilename"
     assert actual == expected
 
@@ -68,7 +74,9 @@ def test_github_url_with_owner_repo_commit_sha():
 
 @pytest.mark.cli
 def test_github_url_with_owner_repo_commit_sha_filename():
-    actual = rawify_url("https://github.com/theownername/thereponame/commit/0123456789abcdef0123456789abcdef01234567/thefilename")
+    actual = rawify_url(
+        "https://github.com/theownername/thereponame/commit/0123456789abcdef0123456789abcdef01234567/thefilename"
+    )
     expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/thefilename"
     assert actual == expected
 
@@ -96,7 +104,9 @@ def test_github_url_with_owner_repo_tree_sha():
 
 @pytest.mark.cli
 def test_github_url_with_owner_repo_tree_sha_filename():
-    actual = rawify_url("https://github.com/theownername/thereponame/tree/0123456789abcdef0123456789abcdef01234567/thefilename")
+    actual = rawify_url(
+        "https://github.com/theownername/thereponame/tree/0123456789abcdef0123456789abcdef01234567/thefilename"
+    )
     expected = "https://raw.githubusercontent.com/theownername/thereponame/0123456789abcdef0123456789abcdef01234567/thefilename"
     assert actual == expected
 

--- a/tests/lib/cff_1_0_3/a/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/a/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_0_3/a/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/a/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_0_3/a/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/a/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,32 +26,28 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
+                "email": "my@email.notexist",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H.",
-            "email": "my@email.notexist"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-01-16"

--- a/tests/lib/cff_1_0_3/a/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/a/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_0_3/a/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/a/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_0_3/a/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/a/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,32 +26,30 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
+                "email": "my@email.notexist",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H.",
-            "email": "my@email.notexist"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -76,8 +73,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.0"

--- a/tests/lib/cff_1_0_3/a/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/a/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,14 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
         ]
 
     def test_keywords(self):
@@ -55,15 +48,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-01-16"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_0_3/b/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/b/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_0_3/b/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/b/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_0_3/b/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/b/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,13 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "givenName": "Gonzalo",
-            "familyName": "Fernández de Córdoba Jr.",
-        }]
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "givenName": "Gonzalo",
+                "familyName": "Fernández de Córdoba Jr.",
+            }
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/b/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/b/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_0_3/b/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/b/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_0_3/b/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/b/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,13 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "givenName": "Gonzalo",
-            "familyName": "Fernández de Córdoba Jr.",
-        }]
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "givenName": "Gonzalo",
+                "familyName": "Fernández de Córdoba Jr.",
+            }
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/b/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/b/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Fernández de Córdoba Jr., Gonzalo"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Fernández de Córdoba Jr., Gonzalo"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_0_3/c/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/c/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_0_3/c/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/c/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_0_3/c/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/c/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,24 +26,21 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-0948-1176",
-            "@type": "Person",
-            "givenName": "Jisk",
-            "familyName": "Attema",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            }
-        }, {
-            "@type": "Person",
-            "givenName": "Faruk",
-            "familyName": "Diblen",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            }
-        }]
+        assert codemeta_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-0948-1176",
+                "@type": "Person",
+                "givenName": "Jisk",
+                "familyName": "Attema",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+            },
+            {
+                "@type": "Person",
+                "givenName": "Faruk",
+                "familyName": "Diblen",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+            },
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
@@ -67,7 +63,7 @@ class TestCodemetaObject(Contract):
             "visualization",
             "big data",
             "visual data analytics",
-            "multi-dimensional data"
+            "multi-dimensional data",
         ]
 
     def test_license(self):

--- a/tests/lib/cff_1_0_3/c/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/c/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
@@ -37,8 +36,10 @@ class TestEndnoteObject(Contract):
         assert endnote_object().add_doi().doi == "%R 10.5281/zenodo.1003346\n"
 
     def test_keyword(self):
-        assert endnote_object().add_keyword().keyword == "%K visualization\n%K big data\n" + \
-                                                         "%K visual data analytics\n%K multi-dimensional data\n"
+        assert (
+            endnote_object().add_keyword().keyword
+            == "%K visualization\n%K big data\n" + "%K visual data analytics\n%K multi-dimensional data\n"
+        )
 
     def test_name(self):
         assert endnote_object().add_name().name == "%T spot\n"

--- a/tests/lib/cff_1_0_3/c/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/c/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1003346\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - visualization\nKW  - big data\n" + \
-                                                       "KW  - visual data analytics\nKW  - multi-dimensional data\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - visualization\nKW  - big data\n" + "KW  - visual data analytics\nKW  - multi-dimensional data\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - spot\n"

--- a/tests/lib/cff_1_0_3/c/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/c/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,24 +26,21 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-0948-1176",
-            "@type": "Person",
-            "givenName": "Jisk",
-            "familyName": "Attema",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            }
-        }, {
-            "@type": "Person",
-            "givenName": "Faruk",
-            "familyName": "Diblen",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            }
-        }]
+        assert schemaorg_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-0948-1176",
+                "@type": "Person",
+                "givenName": "Jisk",
+                "familyName": "Attema",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+            },
+            {
+                "@type": "Person",
+                "givenName": "Faruk",
+                "familyName": "Diblen",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+            },
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -70,7 +66,7 @@ class TestSchemaorgObject(Contract):
             "visualization",
             "big data",
             "visual data analytics",
-            "multi-dimensional data"
+            "multi-dimensional data",
         ]
 
     def test_license(self):

--- a/tests/lib/cff_1_0_3/c/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/c/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,15 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Attema, Jisk",
-                "orcid": "0000-0002-0948-1176"
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Diblen, Faruk"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Attema, Jisk", "orcid": "0000-0002-0948-1176"},
+            {"affiliation": "Netherlands eScience Center", "name": "Diblen, Faruk"},
         ]
 
     def test_keywords(self):
@@ -51,7 +43,7 @@ class TestZenodoObject(Contract):
             "visualization",
             "big data",
             "visual data analytics",
-            "multi-dimensional data"
+            "multi-dimensional data",
         ]
 
     def test_license(self):
@@ -61,15 +53,10 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2017-10-07"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1003346",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/NLeSC/spot",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1003346", "relation": "isSupplementedBy", "scheme": "doi"},
+            {"identifier": "https://github.com/NLeSC/spot", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "spot"

--- a/tests/lib/cff_1_0_3/d/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/d/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_0_3/d/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/d/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
@@ -27,8 +26,10 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Spaaks, Jurriaan H. and Klaver, Tom and " + \
-                                                      "Verhoeven, Stefan and Druskat, Stephan}"
+        assert (
+            bibtex_object().add_author().author
+            == "author = {Spaaks, Jurriaan H. and Klaver, Tom and " + "Verhoeven, Stefan and Druskat, Stephan}"
+        )
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/d/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/d/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,48 +26,40 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Verhoeven",
+                "givenName": "Stefan",
             },
-            "familyName": "Verhoeven",
-            "givenName": "Stefan"
-        }, {
-            "@id": "https://orcid.org/0000-0003-4925-7248",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Humboldt-Universität zu Berlin"
+            {
+                "@id": "https://orcid.org/0000-0003-4925-7248",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Humboldt-Universität zu Berlin"},
+                "familyName": "Druskat",
+                "givenName": "Stephan",
             },
-            "familyName": "Druskat",
-            "givenName": "Stephan"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-07-25"

--- a/tests/lib/cff_1_0_3/d/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/d/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
@@ -27,8 +26,10 @@ class TestEndnoteObject(Contract):
         assert actual_endnote == expected_endnote
 
     def test_author(self):
-        assert endnote_object().add_author().author == "%A Spaaks, Jurriaan H.\n%A Klaver, Tom\n" + \
-                                                       "%A Verhoeven, Stefan\n%A Druskat, Stephan\n"
+        assert (
+            endnote_object().add_author().author
+            == "%A Spaaks, Jurriaan H.\n%A Klaver, Tom\n" + "%A Verhoeven, Stefan\n%A Druskat, Stephan\n"
+        )
 
     def test_check_cffobj(self):
         endnote_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/d/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/d/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -30,8 +29,10 @@ class TestRisObject(Contract):
         assert actual_ris == expected_ris
 
     def test_author(self):
-        assert ris_object().add_author().author == "AU  - Spaaks, Jurriaan H.\nAU  - Klaver, Tom\n" + \
-                                                   "AU  - Verhoeven, Stefan\nAU  - Druskat, Stephan\n"
+        assert (
+            ris_object().add_author().author
+            == "AU  - Spaaks, Jurriaan H.\nAU  - Klaver, Tom\n" + "AU  - Verhoeven, Stefan\nAU  - Druskat, Stephan\n"
+        )
 
     def test_check_cffobj(self):
         ris_object().check_cffobj()
@@ -44,8 +45,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_0_3/d/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/d/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,48 +26,42 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Verhoeven",
+                "givenName": "Stefan",
             },
-            "familyName": "Verhoeven",
-            "givenName": "Stefan"
-        }, {
-            "@id": "https://orcid.org/0000-0003-4925-7248",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Humboldt-Universität zu Berlin"
+            {
+                "@id": "https://orcid.org/0000-0003-4925-7248",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Humboldt-Universität zu Berlin"},
+                "familyName": "Druskat",
+                "givenName": "Stephan",
             },
-            "familyName": "Druskat",
-            "givenName": "Stephan"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -92,8 +85,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.1"

--- a/tests/lib/cff_1_0_3/d/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/d/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,23 +34,14 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Verhoeven, Stefan"
-            },
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
+            {"affiliation": "Netherlands eScience Center", "name": "Verhoeven, Stefan"},
             {
                 "affiliation": "Humboldt-Universität zu Berlin",
                 "name": "Druskat, Stephan",
-                "orcid": "0000-0003-4925-7248"
-            }
+                "orcid": "0000-0003-4925-7248",
+            },
         ]
 
     def test_keywords(self):
@@ -64,15 +54,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-07-25"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_0_3/e/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/e/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_0_3/e/test_bibtex_object.py
+++ b/tests/lib/cff_1_0_3/e/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
@@ -27,8 +26,10 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Spaaks, Jurriaan H. and Klaver" + \
-                                                      ", Tom and Verhoeven, Stefan}"
+        assert (
+            bibtex_object().add_author().author
+            == "author = {Spaaks, Jurriaan H. and Klaver" + ", Tom and Verhoeven, Stefan}"
+        )
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/e/test_codemeta_object.py
+++ b/tests/lib/cff_1_0_3/e/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,39 +26,33 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Verhoeven",
+                "givenName": "Stefan",
             },
-            "familyName": "Verhoeven",
-            "givenName": "Stefan"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-05-09"

--- a/tests/lib/cff_1_0_3/e/test_endnote_object.py
+++ b/tests/lib/cff_1_0_3/e/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_0_3/e/test_ris_object.py
+++ b/tests/lib/cff_1_0_3/e/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -30,8 +29,10 @@ class TestRisObject(Contract):
         assert actual_ris == expected_ris
 
     def test_author(self):
-        assert ris_object().add_author().author == "AU  - Spaaks, Jurriaan H.\nAU  - Klaver, Tom\n" + \
-                                                   "AU  - Verhoeven, Stefan\n"
+        assert (
+            ris_object().add_author().author
+            == "AU  - Spaaks, Jurriaan H.\nAU  - Klaver, Tom\n" + "AU  - Verhoeven, Stefan\n"
+        )
 
     def test_check_cffobj(self):
         ris_object().check_cffobj()
@@ -44,8 +45,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_0_3/e/test_schemaorg_object.py
+++ b/tests/lib/cff_1_0_3/e/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,39 +26,35 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Verhoeven",
+                "givenName": "Stefan",
             },
-            "familyName": "Verhoeven",
-            "givenName": "Stefan"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -83,8 +78,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "0.0.4"

--- a/tests/lib/cff_1_0_3/e/test_zenodo_object.py
+++ b/tests/lib/cff_1_0_3/e/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,18 +34,9 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Verhoeven, Stefan"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
+            {"affiliation": "Netherlands eScience Center", "name": "Verhoeven, Stefan"},
         ]
 
     def test_keywords(self):
@@ -59,15 +49,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-05-09"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_1_0/a/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/a/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_1_0/a/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/a/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_1_0/a/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/a/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,32 +26,28 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "email": "my@email.notexist",
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "email": "my@email.notexist",
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-01-16"

--- a/tests/lib/cff_1_1_0/a/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/a/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_1_0/a/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/a/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_1_0/a/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/a/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,32 +26,30 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "email": "my@email.notexist",
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "email": "my@email.notexist",
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -76,8 +73,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.0"

--- a/tests/lib/cff_1_1_0/a/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/a/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,14 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
         ]
 
     def test_keywords(self):
@@ -55,15 +48,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-01-16"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_1_0/b/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/b/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_1_0/b/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/b/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_1_0/b/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/b/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,31 +26,27 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-01-16"

--- a/tests/lib/cff_1_1_0/b/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/b/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_1_0/b/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/b/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_1_0/b/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/b/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,31 +26,29 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -75,8 +72,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.0"

--- a/tests/lib/cff_1_1_0/b/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/b/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,14 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
         ]
 
     def test_keywords(self):
@@ -55,15 +48,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-01-16"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_1_0/c/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/c/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_1_0/c/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/c/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_1_0/c/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/c/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,31 +26,27 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-01-16"

--- a/tests/lib/cff_1_1_0/c/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/c/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_1_0/c/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/c/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_1_0/c/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/c/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,31 +26,29 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -75,8 +72,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.0"

--- a/tests/lib/cff_1_1_0/c/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/c/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,14 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
         ]
 
     def test_keywords(self):
@@ -55,19 +48,15 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-01-16"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "10.0000/FIXME",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {"identifier": "10.0000/FIXME", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_1_0/d/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/d/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_1_0/d/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/d/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_1_0/d/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/d/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,31 +26,27 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-01-16"

--- a/tests/lib/cff_1_1_0/d/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/d/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_1_0/d/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/d/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_1_0/d/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/d/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,31 +26,29 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -75,8 +72,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.0"

--- a/tests/lib/cff_1_1_0/d/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/d/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,14 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
         ]
 
     def test_keywords(self):
@@ -55,19 +48,15 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-01-16"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "10.0000/FIXME",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {"identifier": "10.0000/FIXME", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_1_0/e/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/e/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_1_0/e/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/e/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
@@ -27,8 +26,10 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Spaaks, Jurriaan H. and " + \
-            "Klaver, Tom and {mysteryauthor}}"
+        assert (
+            bibtex_object().add_author().author
+            == "author = {Spaaks, Jurriaan H. and " + "Klaver, Tom and {mysteryauthor}}"
+        )
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/e/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/e/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,35 +26,29 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "alternateName": "jspaaks",
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }, {
-            "@type": "Person",
-            "alternateName": "mysteryauthor"
-        }]
+            {"@type": "Person", "alternateName": "mysteryauthor"},
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-01-16"

--- a/tests/lib/cff_1_1_0/e/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/e/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_1_0/e/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/e/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_1_0/e/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/e/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,35 +26,31 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "alternateName": "jspaaks",
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }, {
-            "@type": "Person",
-            "alternateName": "mysteryauthor"
-        }]
+            {"@type": "Person", "alternateName": "mysteryauthor"},
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -79,8 +74,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.0"

--- a/tests/lib/cff_1_1_0/e/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/e/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,17 +34,9 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            },
-            {
-                "name": "mysteryauthor"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
+            {"name": "mysteryauthor"},
         ]
 
     def test_keywords(self):
@@ -58,19 +49,15 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-01-16"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "10.0000/FIXME",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {"identifier": "10.0000/FIXME", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_1_0/f/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/f/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_1_0/f/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/f/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_1_0/f/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/f/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,32 +26,28 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "alternateName": "jspaaks",
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-01-16"

--- a/tests/lib/cff_1_1_0/f/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/f/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_1_0/f/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/f/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_1_0/f/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/f/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,32 +26,30 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "alternateName": "jspaaks",
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -76,8 +73,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.0"

--- a/tests/lib/cff_1_1_0/f/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/f/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,14 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
         ]
 
     def test_keywords(self):
@@ -55,19 +48,15 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-01-16"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "10.0000/FIXME",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {"identifier": "10.0000/FIXME", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_1_0/g/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/g/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_1_0/g/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/g/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
@@ -27,8 +26,10 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {Spaaks, Jurriaan H. and " +\
-            "Klaver, Tom and {mysteryauthor}}"
+        assert (
+            bibtex_object().add_author().author
+            == "author = {Spaaks, Jurriaan H. and " + "Klaver, Tom and {mysteryauthor}}"
+        )
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/g/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/g/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,39 +26,33 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "alternateName": "jspaaks",
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "MyAffiliation"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "MyAffiliation"},
+                "alternateName": "mysteryauthor",
             },
-            "alternateName": "mysteryauthor"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                               "/cffconvert"
+        assert codemeta_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_date_published(self):
         assert codemeta_object().add_date_published().date_published == "2018-01-16"

--- a/tests/lib/cff_1_1_0/g/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/g/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_1_0/g/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/g/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -43,8 +42,10 @@ class TestRisObject(Contract):
         assert ris_object().add_doi().doi == "DO  - 10.5281/zenodo.1162057\n"
 
     def test_keywords(self):
-        assert ris_object().add_keywords().keywords == "KW  - citation\nKW  - bibliography\n" + \
-                                                       "KW  - cff\nKW  - CITATION.cff\n"
+        assert (
+            ris_object().add_keywords().keywords
+            == "KW  - citation\nKW  - bibliography\n" + "KW  - cff\nKW  - CITATION.cff\n"
+        )
 
     def test_title(self):
         assert ris_object().add_title().title == "TI  - cffconvert\n"

--- a/tests/lib/cff_1_1_0/g/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/g/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,39 +26,35 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "Spaaks",
+                "givenName": "Jurriaan H.",
             },
-            "alternateName": "jspaaks",
-            "familyName": "Spaaks",
-            "givenName": "Jurriaan H."
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "familyName": "Klaver",
+                "givenName": "Tom",
             },
-            "familyName": "Klaver",
-            "givenName": "Tom"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "MyAffiliation"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "MyAffiliation"},
+                "alternateName": "mysteryauthor",
             },
-            "alternateName": "mysteryauthor"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_code_repository(self):
-        assert schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + \
-                                                                "/cffconvert"
+        assert (
+            schemaorg_object().add_urls().code_repository == "https://github.com/citation-file-format" + "/cffconvert"
+        )
 
     def test_contributor(self):
         assert schemaorg_object().add_contributor().contributor is None
@@ -83,8 +78,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_name().name == "cffconvert"
 
     def test_url(self):
-        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + \
-                                                    "/cffconvert"
+        assert schemaorg_object().add_urls().url == "https://github.com/citation-file-format" + "/cffconvert"
 
     def test_version(self):
         assert schemaorg_object().add_version().version == "1.0.0"

--- a/tests/lib/cff_1_1_0/g/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/g/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,18 +34,9 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Spaaks, Jurriaan H."
-            },
-            {
-                "affiliation": "Netherlands eScience Center",
-                "name": "Klaver, Tom"
-            },
-            {
-                "name": "mysteryauthor",
-                "affiliation": "MyAffiliation"
-            }
+            {"affiliation": "Netherlands eScience Center", "name": "Spaaks, Jurriaan H."},
+            {"affiliation": "Netherlands eScience Center", "name": "Klaver, Tom"},
+            {"name": "mysteryauthor", "affiliation": "MyAffiliation"},
         ]
 
     def test_keywords(self):
@@ -59,19 +49,15 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date == "2018-01-16"
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.5281/zenodo.1162057",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "10.0000/FIXME",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "https://github.com/citation-file-format/cffconvert",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.5281/zenodo.1162057", "relation": "isSupplementedBy", "scheme": "doi"},
+            {"identifier": "10.0000/FIXME", "relation": "isSupplementedBy", "scheme": "doi"},
+            {
+                "identifier": "https://github.com/citation-file-format/cffconvert",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "cffconvert"

--- a/tests/lib/cff_1_1_0/h/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/h/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_1_0/h/test_bibtex_object.py
+++ b/tests/lib/cff_1_1_0/h/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_1_0/h/test_codemeta_object.py
+++ b/tests/lib/cff_1_1_0/h/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,23 +26,20 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Springsteen"
+        assert codemeta_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Springsteen"},
+                "familyName": "Van Zandt",
+                "givenName": "Steven",
             },
-            "familyName": "Van Zandt",
-            "givenName": "Steven"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "coverband"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "coverband"},
+                "familyName": "van Zandt",
+                "givenName": "Steven",
             },
-            "familyName": "van Zandt",
-            "givenName": "Steven"
-        }]
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/h/test_endnote_object.py
+++ b/tests/lib/cff_1_1_0/h/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_1_0/h/test_ris_object.py
+++ b/tests/lib/cff_1_1_0/h/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_1_0/h/test_schemaorg_object.py
+++ b/tests/lib/cff_1_1_0/h/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,23 +26,20 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Springsteen"
+        assert schemaorg_object().add_author().author == [
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Springsteen"},
+                "familyName": "Van Zandt",
+                "givenName": "Steven",
             },
-            "familyName": "Van Zandt",
-            "givenName": "Steven"
-        }, {
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "coverband"
+            {
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "coverband"},
+                "familyName": "van Zandt",
+                "givenName": "Steven",
             },
-            "familyName": "van Zandt",
-            "givenName": "Steven"
-        }]
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/h/test_zenodo_object.py
+++ b/tests/lib/cff_1_1_0/h/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,14 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "affiliation": "Springsteen",
-                "name": "Van Zandt, Steven"
-            },
-            {
-                "affiliation": "coverband",
-                "name": "van Zandt, Steven"
-            }
+            {"affiliation": "Springsteen", "name": "Van Zandt, Steven"},
+            {"affiliation": "coverband", "name": "van Zandt, Steven"},
         ]
 
     def test_keywords(self):

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "von der Spaaks Jr. J.H."
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {von der Spaaks Jr., Jurriaan H.}"
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_codemeta_object.py
@@ -18,24 +18,22 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "email": "my@email.notexist",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert codemeta_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "email": "my@email.notexist",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_schemaorg_object.py
@@ -18,24 +18,22 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "email": "my@email.notexist",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert schemaorg_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "email": "my@email.notexist",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -38,7 +37,7 @@ class TestZenodoObject(Contract):
             {
                 "affiliation": "Netherlands eScience Center",
                 "name": "von der Spaaks Jr., Jurriaan H.",
-                "orcid": "0000-0002-7064-4069"
+                "orcid": "0000-0002-7064-4069",
             }
         ]
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "von der Spaaks Jr. J.H."
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {von der Spaaks Jr., Jurriaan H.}"
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_codemeta_object.py
@@ -18,23 +18,21 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert codemeta_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_schemaorg_object.py
@@ -18,23 +18,21 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert schemaorg_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -38,7 +37,7 @@ class TestZenodoObject(Contract):
             {
                 "affiliation": "Netherlands eScience Center",
                 "name": "von der Spaaks Jr., Jurriaan H.",
-                "orcid": "0000-0002-7064-4069"
+                "orcid": "0000-0002-7064-4069",
             }
         ]
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,12 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,12 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III, Rafael"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "van der Vaart III, Rafael"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III, Rafael"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "van der Vaart III, Rafael"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "givenName": "Rafael"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Rafael"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Rafael"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "givenName": "Rafael"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Person", "givenName": "Rafael"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Person", "givenName": "Rafael"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Rafael"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Rafael"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "van der Vaart III"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Person", "familyName": "van der Vaart III"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Person", "familyName": "van der Vaart III"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "van der Vaart III"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "alternateName": "Rafa",
-            "name": "The soccer team members"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Organization", "alternateName": "Rafa", "name": "The soccer team members"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "alternateName": "Rafa",
-            "name": "The soccer team members"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Organization", "alternateName": "Rafa", "name": "The soccer team members"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The soccer team members"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The soccer team members"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The soccer team members"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "The soccer team members"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The soccer team members"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The soccer team members"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -30,11 +29,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The soccer team members"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The soccer team members"}]
 
     def test_check_cffobj(self):
         zenodo_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
@@ -27,8 +26,10 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {van der Vaart III, Rafael and dos " + \
-                                                      "Santos Aveiro, Cristiano Ronaldo}"
+        assert (
+            bibtex_object().add_author().author
+            == "author = {van der Vaart III, Rafael and dos " + "Santos Aveiro, Cristiano Ronaldo}"
+        )
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,15 +26,10 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }, {
-            "@type": "Person",
-            "familyName": "dos Santos Aveiro",
-            "givenName": "Cristiano Ronaldo"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"},
+            {"@type": "Person", "familyName": "dos Santos Aveiro", "givenName": "Cristiano Ronaldo"},
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
@@ -27,8 +26,10 @@ class TestEndnoteObject(Contract):
         assert actual_endnote == expected_endnote
 
     def test_author(self):
-        assert endnote_object().add_author().author == "%A van der Vaart III, Rafael\n" + \
-                                                       "%A dos Santos Aveiro, Cristiano Ronaldo\n"
+        assert (
+            endnote_object().add_author().author
+            == "%A van der Vaart III, Rafael\n" + "%A dos Santos Aveiro, Cristiano Ronaldo\n"
+        )
 
     def test_check_cffobj(self):
         endnote_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -30,8 +29,10 @@ class TestRisObject(Contract):
         assert actual_ris == expected_ris
 
     def test_author(self):
-        assert ris_object().add_author().author == "AU  - van der Vaart III, Rafael\n" + \
-                                                   "AU  - dos Santos Aveiro, Cristiano Ronaldo\n"
+        assert (
+            ris_object().add_author().author
+            == "AU  - van der Vaart III, Rafael\n" + "AU  - dos Santos Aveiro, Cristiano Ronaldo\n"
+        )
 
     def test_check_cffobj(self):
         ris_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,15 +26,10 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }, {
-            "@type": "Person",
-            "familyName": "dos Santos Aveiro",
-            "givenName": "Cristiano Ronaldo"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"},
+            {"@type": "Person", "familyName": "dos Santos Aveiro", "givenName": "Cristiano Ronaldo"},
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,12 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III, Rafael"
-            },
-            {
-                "name": "dos Santos Aveiro, Cristiano Ronaldo"
-            }
+            {"name": "van der Vaart III, Rafael"},
+            {"name": "dos Santos Aveiro, Cristiano Ronaldo"},
         ]
 
     def test_keywords(self):

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,15 +45,10 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.0000/from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "10.0000/from-doi",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.0000/from-identifiers", "relation": "isSupplementedBy", "scheme": "doi"},
+            {"identifier": "10.0000/from-doi", "relation": "isSupplementedBy", "scheme": "doi"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.0000/some-doi",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.0000/some-doi", "relation": "isSupplementedBy", "scheme": "doi"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.0000/from-doi",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.0000/from-doi", "relation": "isSupplementedBy", "scheme": "doi"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.0000/from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.0000/from-identifiers", "relation": "isSupplementedBy", "scheme": "doi"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/identifiers/__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_2_0/identifiers/__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_2_0/identifiers/__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_2_0/identifiers/__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/identifiers/__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/types/dataset/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/types/dataset/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The name"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The name"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/types/dataset/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/types/dataset/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The name"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The name"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/types/none/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/types/none/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The name"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The name"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/types/none/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/types/none/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The name"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The name"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/types/software/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/types/software/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The name"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The name"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/types/software/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/types/software/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The name"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The name"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,27 +45,29 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,28 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,24 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,23 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,24 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,23 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/IR___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/IR___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/IR___/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/IR___/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/IR___/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/IR___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/IR___/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,24 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,23 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/I___U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/I___U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/I___U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/I___U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/I___U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/I___U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/I___U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/I____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/I____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/I____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/I____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/I____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/I____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/I____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,13 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            }
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,24 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,23 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_R___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_R___/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_R___/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/_R___/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_R___/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_R___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_2_0/urls/_R___/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,13 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            }
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/__A__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/__A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/__A__/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/__A__/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/__A__/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/__A__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/__A__/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,13 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            }
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/___CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/___CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/___CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/___CU/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/___CU/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/___CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/___CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/___C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/___C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/___C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/___C_/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/___C_/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/___C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_2_0/urls/___C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,13 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            }
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/____U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/____U/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/____U/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/____U/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/____U/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/____U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/____U/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_2_0/urls/_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_2_0/urls/_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_2_0/urls/_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/_____/test_endnote_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_2_0/urls/_____/test_ris_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_2_0/urls/_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_2_0/urls/_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "von der Spaaks Jr. J.H."
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {von der Spaaks Jr., Jurriaan H.}"
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_codemeta_object.py
@@ -18,24 +18,22 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "email": "my@email.notexist",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert codemeta_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "email": "my@email.notexist",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_schemaorg_object.py
@@ -18,24 +18,22 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "email": "my@email.notexist",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert schemaorg_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "email": "my@email.notexist",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -38,7 +37,7 @@ class TestZenodoObject(Contract):
             {
                 "affiliation": "Netherlands eScience Center",
                 "name": "von der Spaaks Jr., Jurriaan H.",
-                "orcid": "0000-0002-7064-4069"
+                "orcid": "0000-0002-7064-4069",
             }
         ]
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "von der Spaaks Jr. J.H."
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {von der Spaaks Jr., Jurriaan H.}"
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_codemeta_object.py
@@ -18,23 +18,21 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert codemeta_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_schemaorg_object.py
@@ -18,23 +18,21 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert schemaorg_object().add_author().author == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -38,7 +37,7 @@ class TestZenodoObject(Contract):
             {
                 "affiliation": "Netherlands eScience Center",
                 "name": "von der Spaaks Jr., Jurriaan H.",
-                "orcid": "0000-0002-7064-4069"
+                "orcid": "0000-0002-7064-4069",
             }
         ]
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,12 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,12 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III, Rafael"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "van der Vaart III, Rafael"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III, Rafael"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "van der Vaart III, Rafael"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "givenName": "Rafael"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "givenName": "Rafael"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Rafael"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Rafael"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "givenName": "Rafael"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Person", "givenName": "Rafael"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Person", "givenName": "Rafael"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Rafael"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Rafael"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "van der Vaart III"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Person", "familyName": "van der Vaart III"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Person", "familyName": "van der Vaart III"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "van der Vaart III"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,11 +26,9 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "alternateName": "Rafa",
-            "name": "The soccer team members"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Organization", "alternateName": "Rafa", "name": "The soccer team members"}
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,11 +26,9 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "alternateName": "Rafa",
-            "name": "The soccer team members"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Organization", "alternateName": "Rafa", "name": "The soccer team members"}
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The soccer team members"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The soccer team members"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Person", "alternateName": "Rafa"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "alternateName": "Rafa"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Person", "alternateName": "Rafa"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -30,11 +29,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Rafa"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Rafa"}]
 
     def test_check_cffobj(self):
         zenodo_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The soccer team members"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "The soccer team members"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The soccer team members"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The soccer team members"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -30,11 +29,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The soccer team members"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The soccer team members"}]
 
     def test_check_cffobj(self):
         zenodo_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")
@@ -27,8 +26,10 @@ class TestBibtexObject(Contract):
         assert actual_bibtex == expected_bibtex
 
     def test_author(self):
-        assert bibtex_object().add_author().author == "author = {van der Vaart III, Rafael and dos " + \
-                                                      "Santos Aveiro, Cristiano Ronaldo}"
+        assert (
+            bibtex_object().add_author().author
+            == "author = {van der Vaart III, Rafael and dos " + "Santos Aveiro, Cristiano Ronaldo}"
+        )
 
     def test_check_cffobj(self):
         bibtex_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,15 +26,10 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }, {
-            "@type": "Person",
-            "familyName": "dos Santos Aveiro",
-            "givenName": "Cristiano Ronaldo"
-        }]
+        assert codemeta_object().add_author().author == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"},
+            {"@type": "Person", "familyName": "dos Santos Aveiro", "givenName": "Cristiano Ronaldo"},
+        ]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")
@@ -27,8 +26,10 @@ class TestEndnoteObject(Contract):
         assert actual_endnote == expected_endnote
 
     def test_author(self):
-        assert endnote_object().add_author().author == "%A van der Vaart III, Rafael\n" + \
-                                                       "%A dos Santos Aveiro, Cristiano Ronaldo\n"
+        assert (
+            endnote_object().add_author().author
+            == "%A van der Vaart III, Rafael\n" + "%A dos Santos Aveiro, Cristiano Ronaldo\n"
+        )
 
     def test_check_cffobj(self):
         endnote_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 
@@ -30,8 +29,10 @@ class TestRisObject(Contract):
         assert actual_ris == expected_ris
 
     def test_author(self):
-        assert ris_object().add_author().author == "AU  - van der Vaart III, Rafael\n" + \
-                                                   "AU  - dos Santos Aveiro, Cristiano Ronaldo\n"
+        assert (
+            ris_object().add_author().author
+            == "AU  - van der Vaart III, Rafael\n" + "AU  - dos Santos Aveiro, Cristiano Ronaldo\n"
+        )
 
     def test_check_cffobj(self):
         ris_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,15 +26,10 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }, {
-            "@type": "Person",
-            "familyName": "dos Santos Aveiro",
-            "givenName": "Cristiano Ronaldo"
-        }]
+        assert schemaorg_object().add_author().author == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"},
+            {"@type": "Person", "familyName": "dos Santos Aveiro", "givenName": "Cristiano Ronaldo"},
+        ]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -35,12 +34,8 @@ class TestZenodoObject(Contract):
 
     def test_creators(self):
         assert zenodo_object().add_creators().creators == [
-            {
-                "name": "van der Vaart III, Rafael"
-            },
-            {
-                "name": "dos Santos Aveiro, Cristiano Ronaldo"
-            }
+            {"name": "van der Vaart III, Rafael"},
+            {"name": "dos Santos Aveiro, Cristiano Ronaldo"},
         ]
 
     def test_keywords(self):

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,18 +36,17 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "email": "my@email.notexist",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "email": "my@email.notexist",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -36,16 +35,12 @@ class TestZenodoObject(Contract):
                 "affiliation": "Netherlands eScience Center",
                 "name": "von der Spaaks Jr., Jurriaan H.",
                 "orcid": "0000-0002-7064-4069",
-                "type": "Other"
+                "type": "Other",
             }
         ]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,17 +36,16 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@id": "https://orcid.org/0000-0002-7064-4069",
-            "@type": "Person",
-            "affiliation": {
-                "@type": "Organization",
-                "name": "Netherlands eScience Center"
-            },
-            "alternateName": "jspaaks",
-            "familyName": "von der Spaaks Jr.",
-            "givenName": "Jurriaan H."
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {
+                "@id": "https://orcid.org/0000-0002-7064-4069",
+                "@type": "Person",
+                "affiliation": {"@type": "Organization", "name": "Netherlands eScience Center"},
+                "alternateName": "jspaaks",
+                "familyName": "von der Spaaks Jr.",
+                "givenName": "Jurriaan H.",
+            }
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -36,16 +35,12 @@ class TestZenodoObject(Contract):
                 "affiliation": "Netherlands eScience Center",
                 "name": "von der Spaaks Jr., Jurriaan H.",
                 "orcid": "0000-0002-7064-4069",
-                "type": "Other"
+                "type": "Other",
             }
         ]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,12 +36,9 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -32,18 +31,11 @@ class TestZenodoObject(Contract):
 
     def test_contributors(self):
         assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "van der Vaart III, Rafael",
-                "type": "Other"
-            }
+            {"name": "van der Vaart III, Rafael", "type": "Other"}
         ]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,11 +36,9 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"}
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -32,18 +31,11 @@ class TestZenodoObject(Contract):
 
     def test_contributors(self):
         assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "van der Vaart III, Rafael",
-                "type": "Other"
-            }
+            {"name": "van der Vaart III, Rafael", "type": "Other"}
         ]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,11 +36,9 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {"@type": "Person", "alternateName": "Rafa", "givenName": "Rafael"}
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -31,19 +30,10 @@ class TestZenodoObject(Contract):
         # doesn't need an assert
 
     def test_contributors(self):
-        assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "Rafael",
-                "type": "Other"
-            }
-        ]
+        assert zenodo_object().add_contributors().contributors == [{"name": "Rafael", "type": "Other"}]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,10 +36,7 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Person",
-            "givenName": "Rafael"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [{"@type": "Person", "givenName": "Rafael"}]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -31,19 +30,10 @@ class TestZenodoObject(Contract):
         # doesn't need an assert
 
     def test_contributors(self):
-        assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "Rafael",
-                "type": "Other"
-            }
-        ]
+        assert zenodo_object().add_contributors().contributors == [{"name": "Rafael", "type": "Other"}]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,11 +36,9 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Person",
-            "alternateName": "Rafa",
-            "familyName": "van der Vaart III"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {"@type": "Person", "alternateName": "Rafa", "familyName": "van der Vaart III"}
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -31,19 +30,10 @@ class TestZenodoObject(Contract):
         # doesn't need an assert
 
     def test_contributors(self):
-        assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "van der Vaart III",
-                "type": "Other"
-            }
-        ]
+        assert zenodo_object().add_contributors().contributors == [{"name": "van der Vaart III", "type": "Other"}]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,10 +36,9 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {"@type": "Person", "familyName": "van der Vaart III"}
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -31,19 +30,10 @@ class TestZenodoObject(Contract):
         # doesn't need an assert
 
     def test_contributors(self):
-        assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "van der Vaart III",
-                "type": "Other"
-            }
-        ]
+        assert zenodo_object().add_contributors().contributors == [{"name": "van der Vaart III", "type": "Other"}]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,11 +36,9 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Organization",
-            "alternateName": "Rafa",
-            "name": "The soccer team members"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {"@type": "Organization", "alternateName": "Rafa", "name": "The soccer team members"}
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -31,19 +30,10 @@ class TestZenodoObject(Contract):
         # doesn't need an assert
 
     def test_contributors(self):
-        assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "The soccer team members",
-                "type": "Other"
-            }
-        ]
+        assert zenodo_object().add_contributors().contributors == [{"name": "The soccer team members", "type": "Other"}]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,10 +36,9 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Organization",
-            "name": "The soccer team members"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {"@type": "Organization", "name": "The soccer team members"}
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -27,19 +26,10 @@ class TestZenodoObject(Contract):
         assert actual_zenodo == expected_zenodo
 
     def test_contributors(self):
-        assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "The soccer team members",
-                "type": "Other"
-            }
-        ]
+        assert zenodo_object().add_contributors().contributors == [{"name": "The soccer team members", "type": "Other"}]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_check_cffobj(self):
         zenodo_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
@@ -40,15 +36,10 @@ class TestSchemaorgObject(Contract):
         assert schemaorg_object().add_urls().code_repository is None
 
     def test_contributor(self):
-        assert schemaorg_object().add_contributor().contributor == [{
-            "@type": "Person",
-            "familyName": "van der Vaart III",
-            "givenName": "Rafael"
-        }, {
-            "@type": "Person",
-            "familyName": "dos Santos Aveiro",
-            "givenName": "Cristiano Ronaldo"
-        }]
+        assert schemaorg_object().add_contributor().contributor == [
+            {"@type": "Person", "familyName": "van der Vaart III", "givenName": "Rafael"},
+            {"@type": "Person", "familyName": "dos Santos Aveiro", "givenName": "Cristiano Ronaldo"},
+        ]
 
     def test_date_published(self):
         assert schemaorg_object().add_date_published().date_published is None

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -32,22 +31,12 @@ class TestZenodoObject(Contract):
 
     def test_contributors(self):
         assert zenodo_object().add_contributors().contributors == [
-            {
-                "name": "van der Vaart III, Rafael",
-                "type": "Other"
-            },
-            {
-                "name": "dos Santos Aveiro, Cristiano Ronaldo",
-                "type": "Other"
-            }
+            {"name": "van der Vaart III, Rafael", "type": "Other"},
+            {"name": "dos Santos Aveiro, Cristiano Ronaldo", "type": "Other"},
         ]
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/identifiers/relation/test_zenodo_related_identifiers.py
+++ b/tests/lib/cff_1_3_0/identifiers/relation/test_zenodo_related_identifiers.py
@@ -41,19 +41,12 @@ def get_relation_types():
         "Obsoletes",
         "References",
         "Requires",
-        "Reviews"
+        "Reviews",
     ]
 
 
 def get_relation_types_skip():
-    return [
-        "HasMetadata",
-        "HasVersion",
-        "IsMetadataFor",
-        "IsOriginalFormOf",
-        "IsVariantFormOf",
-        "IsVersionOf"
-    ]
+    return ["HasMetadata", "HasVersion", "IsMetadataFor", "IsOriginalFormOf", "IsVariantFormOf", "IsVersionOf"]
 
 
 @pytest.mark.lib

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,15 +45,10 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.0000/from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }, {
-            "identifier": "10.0000/from-doi",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.0000/from-identifiers", "relation": "isSupplementedBy", "scheme": "doi"},
+            {"identifier": "10.0000/from-doi", "relation": "isSupplementedBy", "scheme": "doi"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.0000/some-doi",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.0000/some-doi", "relation": "isSupplementedBy", "scheme": "doi"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/somewhere",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "https://github.com/somewhere", "relation": "isSupplementedBy", "scheme": "url"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.0000/from-doi",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.0000/from-doi", "relation": "isSupplementedBy", "scheme": "doi"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -50,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "10.0000/from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "doi"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "10.0000/from-identifiers", "relation": "isSupplementedBy", "scheme": "doi"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_as_string(self):
         actual_apalike = apalike_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_as_string(self):
         actual_bibtex = bibtex_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "bibtex.bib")

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_codemeta_object.py
@@ -18,7 +18,6 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_as_string(self):
         actual_codemeta = codemeta_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "codemeta.json")
@@ -27,10 +26,7 @@ class TestCodemetaObject(Contract):
         assert actual_codemeta == expected_codemeta
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_as_string(self):
         actual_endnote = endnote_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "endnote.enw")

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "Test author"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/types/dataset/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/types/dataset/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The name"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The name"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/types/dataset/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/types/dataset/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The name"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The name"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/types/none/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/types/none/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The name"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The name"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/types/none/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/types/none/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The name"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The name"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/types/software/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/types/software/test_schemaorg_object.py
@@ -18,7 +18,6 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_as_string(self):
         actual_schemaorg = schemaorg_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), "schemaorg.json")
@@ -27,10 +26,7 @@ class TestSchemaorgObject(Contract):
         assert actual_schemaorg == expected_schemaorg
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "The name"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "The name"}]
 
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/types/software/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/types/software/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,11 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [
-            {
-                "name": "The name"
-            }
-        ]
+        assert zenodo_object().add_creators().creators == [{"name": "The name"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,27 +45,29 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,28 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,24 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,23 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,24 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,23 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/IR___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/IR___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/IR___/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/IR___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/IR___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/IR___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/IR___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,24 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,23 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/I___U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/I___U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/I___U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/I___U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/I___U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/I___U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/I___U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/I____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/I____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/I____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/I____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/I____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/I____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/I____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,13 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-identifiers",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-identifiers",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            }
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,23 +45,24 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,23 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_R___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_R___/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_R___/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/_R___/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_R___/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_R___/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository"

--- a/tests/lib/cff_1_3_0/urls/_R___/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,13 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            }
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,19 +45,19 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,18 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/__A__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/__A__/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/__A__/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/__A__/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/__A__/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/__A__/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/__A__/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,13 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-artifact",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-artifact",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            }
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/___CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/___CU/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/___CU/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/___CU/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/___CU/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/___CU/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/___CU/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,15 +45,14 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }, {
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            },
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"},
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/___C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/___C_/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/___C_/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/___C_/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/___C_/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/___C_/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository == "https://github.com/the-url-from-repository-code"

--- a/tests/lib/cff_1_3_0/urls/___C_/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,13 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-repository-code",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {
+                "identifier": "https://github.com/the-url-from-repository-code",
+                "relation": "isSupplementedBy",
+                "scheme": "url",
+            }
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/____U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/____U/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/____U/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/____U/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/____U/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/____U/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/____U/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None
@@ -48,11 +45,9 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_publication_date().publication_date is None
 
     def test_related_identifiers(self):
-        assert zenodo_object().add_related_identifiers().related_identifiers == [{
-            "identifier": "https://github.com/the-url-from-url",
-            "relation": "isSupplementedBy",
-            "scheme": "url"
-        }]
+        assert zenodo_object().add_related_identifiers().related_identifiers == [
+            {"identifier": "https://github.com/the-url-from-url", "relation": "isSupplementedBy", "scheme": "url"}
+        ]
 
     def test_title(self):
         assert zenodo_object().add_title().title == "Test title"

--- a/tests/lib/cff_1_3_0/urls/_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_apalike_object.py
@@ -18,7 +18,6 @@ def apalike_object():
 @pytest.mark.lib
 @pytest.mark.apalike
 class TestApalikeObject(Contract):
-
     def test_author(self):
         assert apalike_object().add_author().author == "Test author"
 

--- a/tests/lib/cff_1_3_0/urls/_____/test_bibtex_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_bibtex_object.py
@@ -18,7 +18,6 @@ def bibtex_object():
 @pytest.mark.lib
 @pytest.mark.bibtex
 class TestBibtexObject(Contract):
-
     def test_author(self):
         assert bibtex_object().add_author().author == "author = {{Test author}}"
 

--- a/tests/lib/cff_1_3_0/urls/_____/test_codemeta_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_codemeta_object.py
@@ -18,16 +18,12 @@ def codemeta_object():
 @pytest.mark.lib
 @pytest.mark.codemeta
 class TestCodemetaObject(Contract):
-
     def test_check_cffobj(self):
         codemeta_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert codemeta_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert codemeta_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert codemeta_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/_____/test_endnote_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_endnote_object.py
@@ -18,7 +18,6 @@ def endnote_object():
 @pytest.mark.lib
 @pytest.mark.endnote
 class TestEndnoteObject(Contract):
-
     def test_check_cffobj(self):
         endnote_object().check_cffobj()
         # doesn't need an assert

--- a/tests/lib/cff_1_3_0/urls/_____/test_ris_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_ris_object.py
@@ -18,7 +18,6 @@ def ris_object():
 @pytest.mark.lib
 @pytest.mark.ris
 class TestRisObject(Contract):
-
     def test_abstract(self):
         assert ris_object().add_abstract().abstract is None
 

--- a/tests/lib/cff_1_3_0/urls/_____/test_schemaorg_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_schemaorg_object.py
@@ -18,16 +18,12 @@ def schemaorg_object():
 @pytest.mark.lib
 @pytest.mark.schemaorg
 class TestSchemaorgObject(Contract):
-
     def test_check_cffobj(self):
         schemaorg_object().check_cffobj()
         # doesn't need an assert
 
     def test_author(self):
-        assert schemaorg_object().add_author().author == [{
-            "@type": "Organization",
-            "name": "Test author"
-        }]
+        assert schemaorg_object().add_author().author == [{"@type": "Organization", "name": "Test author"}]
 
     def test_code_repository(self):
         assert schemaorg_object().add_urls().code_repository is None

--- a/tests/lib/cff_1_3_0/urls/_____/test_zenodo_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_zenodo_object.py
@@ -18,7 +18,6 @@ def zenodo_object():
 @pytest.mark.lib
 @pytest.mark.zenodo
 class TestZenodoObject(Contract):
-
     def test_as_string(self):
         actual_zenodo = zenodo_object().add_all().as_string()
         fixture = os.path.join(os.path.dirname(__file__), ".zenodo.json")
@@ -34,9 +33,7 @@ class TestZenodoObject(Contract):
         assert zenodo_object().add_contributors().contributors is None
 
     def test_creators(self):
-        assert zenodo_object().add_creators().creators == [{
-            "name": "Test author"
-        }]
+        assert zenodo_object().add_creators().creators == [{"name": "Test author"}]
 
     def test_keywords(self):
         assert zenodo_object().add_keywords().keywords is None

--- a/tests/lib/cff_1_x_x/authors/get_every_key.py
+++ b/tests/lib/cff_1_x_x/authors/get_every_key.py
@@ -16,6 +16,6 @@ def get_every_key():
         name_values,
         affiliation_values,
         orcid_values,
-        email_values
+        email_values,
     ]
     return ["".join(combo) for combo in itertools.product(*combined)]

--- a/tests/lib/cff_1_x_x/urls/get_every_key.py
+++ b/tests/lib/cff_1_x_x/urls/get_every_key.py
@@ -12,6 +12,6 @@ def get_every_key():
         repository_values,
         repository_artifact_values,
         repository_code_values,
-        url_values
+        url_values,
     ]
     return ["".join(combo) for combo in itertools.product(*combined)]

--- a/tests/lib/contracts/apalike.py
+++ b/tests/lib/contracts/apalike.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class Contract(ABC):
-
     @abstractmethod
     def test_author(self):
         pass

--- a/tests/lib/contracts/bibtex.py
+++ b/tests/lib/contracts/bibtex.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class Contract(ABC):
-
     @abstractmethod
     def test_author(self):
         pass

--- a/tests/lib/contracts/codemeta.py
+++ b/tests/lib/contracts/codemeta.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class Contract(ABC):
-
     @abstractmethod
     def test_check_cffobj(self):
         pass

--- a/tests/lib/contracts/endnote.py
+++ b/tests/lib/contracts/endnote.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class Contract(ABC):
-
     @abstractmethod
     def test_check_cffobj(self):
         pass

--- a/tests/lib/contracts/ris.py
+++ b/tests/lib/contracts/ris.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class Contract(ABC):
-
     @abstractmethod
     def test_abstract(self):
         pass

--- a/tests/lib/contracts/schemaorg.py
+++ b/tests/lib/contracts/schemaorg.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class Contract(ABC):
-
     @abstractmethod
     def test_check_cffobj(self):
         pass

--- a/tests/lib/contracts/zenodo.py
+++ b/tests/lib/contracts/zenodo.py
@@ -3,7 +3,6 @@ from abc import abstractmethod
 
 
 class Contract(ABC):
-
     @abstractmethod
     def test_check_cffobj(self):
         pass

--- a/tests/test_consistent_versioning.py
+++ b/tests/test_consistent_versioning.py
@@ -69,8 +69,9 @@ def test_readme_dev_md_3():
     fixture = os.path.join(os.path.dirname(__file__), "..", "README.dev.md")
     with open(fixture, "rt", encoding="utf-8") as fid:
         file_contents = fid.read()
-    regex = re.compile(r"^docker tag cffconvert:(?P<version1>\S*) citationcff/" +
-                       r"cffconvert:(?P<version2>\S*)$", re.MULTILINE)
+    regex = re.compile(
+        r"^docker tag cffconvert:(?P<version1>\S*) citationcff/" + r"cffconvert:(?P<version2>\S*)$", re.MULTILINE
+    )
     actual_version_1 = re.search(regex, file_contents)["version1"]
     actual_version_2 = re.search(regex, file_contents)["version2"]
     assert actual_version_1 == expected_version


### PR DESCRIPTION
This PR updates the dependencies for isort and ruff. Running `ruff format` afterwards.