### PR TITLE
Fix conversion to APA style

### DIFF
--- a/src/cffconvert/__init__.py
+++ b/src/cffconvert/__init__.py
@@ -1,6 +1,5 @@
 from cffconvert.lib.citation import Citation
 
-
 __all__ = [
     "Citation"
 ]

--- a/src/cffconvert/__init__.py
+++ b/src/cffconvert/__init__.py
@@ -1,5 +1,6 @@
 from cffconvert.lib.citation import Citation
 
+
 __all__ = [
     "Citation"
 ]

--- a/src/cffconvert/lib/cff_1_0_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_0_x/apalike.py
@@ -25,6 +25,8 @@ class ApalikeObject(Shared):
             self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
         else:
             self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+        if self.author[-1] != ".":
+            self.author += "."
         return self
 
     def add_year(self):

--- a/src/cffconvert/lib/cff_1_0_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_0_x/apalike.py
@@ -21,10 +21,8 @@ class ApalikeObject(Shared):
             pass
         elif n_authors == 1:
             self.author = ", ".join(authors_apalike_filtered)
-        elif n_authors == 2:
-            self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
         else:
-            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", & " + authors_apalike_filtered[-1]
         if self.author[-1] != ".":
             self.author += "."
         return self

--- a/src/cffconvert/lib/cff_1_1_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_1_x/apalike.py
@@ -23,6 +23,8 @@ class ApalikeObject(Shared):
             self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
         else:
             self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+        if self.author[-1] != ".":
+            self.author += "."
         return self
 
     def add_year(self):

--- a/src/cffconvert/lib/cff_1_1_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_1_x/apalike.py
@@ -19,10 +19,8 @@ class ApalikeObject(Shared):
             pass
         elif n_authors == 1:
             self.author = ", ".join(authors_apalike_filtered)
-        elif n_authors == 2:
-            self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
         else:
-            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", & " + authors_apalike_filtered[-1]
         if self.author[-1] != ".":
             self.author += "."
         return self

--- a/src/cffconvert/lib/cff_1_2_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_2_x/apalike.py
@@ -23,6 +23,8 @@ class ApalikeObject(Shared):
             self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
         else:
             self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+        if self.author[-1] != ".":
+            self.author += "."
         return self
 
     def add_year(self):

--- a/src/cffconvert/lib/cff_1_2_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_2_x/apalike.py
@@ -19,10 +19,8 @@ class ApalikeObject(Shared):
             pass
         elif n_authors == 1:
             self.author = ", ".join(authors_apalike_filtered)
-        elif n_authors == 2:
-            self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
         else:
-            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", & " + authors_apalike_filtered[-1]
         if self.author[-1] != ".":
             self.author += "."
         return self

--- a/src/cffconvert/lib/cff_1_3_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_3_x/apalike.py
@@ -23,6 +23,8 @@ class ApalikeObject(Shared):
             self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
         else:
             self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+        if self.author[-1] != ".":
+            self.author += "."
         return self
 
     def add_year(self):

--- a/src/cffconvert/lib/cff_1_3_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_3_x/apalike.py
@@ -19,10 +19,8 @@ class ApalikeObject(Shared):
             pass
         elif n_authors == 1:
             self.author = ", ".join(authors_apalike_filtered)
-        elif n_authors == 2:
-            self.author = ", ".join(authors_apalike_filtered[:-1]) + " and " + authors_apalike_filtered[-1]
         else:
-            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", and " + authors_apalike_filtered[-1]
+            self.author = ", ".join(authors_apalike_filtered[:-1]) + ", & " + authors_apalike_filtered[-1]
         if self.author[-1] != ".":
             self.author += "."
         return self

--- a/src/cffconvert/lib/cff_1_x_x/apalike.py
+++ b/src/cffconvert/lib/cff_1_x_x/apalike.py
@@ -22,7 +22,6 @@ class ApalikeObjectShared:
         self.author = None
         self.year = None
         self.title = None
-        self.version = None
         self.doi = None
         self.url = None
         if initialize_empty:
@@ -36,7 +35,6 @@ class ApalikeObjectShared:
         items = [item for item in [self.author,
                                    self.year,
                                    self.title,
-                                   self.version,
                                    self.doi,
                                    self.url] if item is not None]
         return " ".join(items) + "\n"
@@ -45,7 +43,6 @@ class ApalikeObjectShared:
         self.add_author()   \
             .add_year()     \
             .add_title()    \
-            .add_version()  \
             .add_doi()      \
             .add_url()
         return self
@@ -61,11 +58,16 @@ class ApalikeObjectShared:
     def add_title(self):
         if "title" in self.cffobj.keys():
             self.title = self.cffobj["title"]
-        return self
-
-    def add_version(self):
         if "version" in self.cffobj.keys():
-            self.version = "(version " + str(self.cffobj["version"]) + ")."
+            self.title += " (version " + str(self.cffobj["version"]) + ")"
+        if "type" in self.cffobj.keys():
+            type_cff = self.cffobj.get("type")
+            if type_cff == "dataset":
+                self.title += " [Data set]"
+            elif type_cff == "software":
+                self.title += " [Computer software]"
+        if self.title[-1] != ".":
+            self.title += "."
         return self
 
     @abstractmethod

--- a/src/cffconvert/lib/cff_1_x_x/authors/apalike.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/apalike.py
@@ -141,7 +141,7 @@ class ApalikeAuthor(BaseAuthor):
         return self._author.get("alias")
 
     def _from_given_and_last(self):
-        return self._get_full_last_name() + " " + self._get_initials()
+        return self._get_full_last_name() + ", " + self._get_initials()
 
     def _from_given(self):
         return self._author.get("given-names")

--- a/src/cffconvert/lib/cff_1_x_x/authors/apalike.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/apalike.py
@@ -154,7 +154,14 @@ class ApalikeAuthor(BaseAuthor):
 
     def _get_initials(self):
         given_names = self._author.get("given-names").split(" ")
-        return " ".join([given_name[0] + "." for given_name in given_names])
+        initials = []
+        for given_name in given_names:
+            if "-" in given_name:
+                name_parts = given_name.split("-")
+                initials.append("-".join([name_part[0] + "." for name_part in name_parts]))
+            else:
+                initials.append(given_name[0] + ".")
+        return " ".join(initials)
 
     def as_string(self):
         key = self._get_key()

--- a/src/cffconvert/lib/cff_1_x_x/authors/apalike.py
+++ b/src/cffconvert/lib/cff_1_x_x/authors/apalike.py
@@ -154,7 +154,7 @@ class ApalikeAuthor(BaseAuthor):
 
     def _get_initials(self):
         given_names = self._author.get("given-names").split(" ")
-        return "".join([given_name[0] + "." for given_name in given_names])
+        return " ".join([given_name[0] + "." for given_name in given_names])
 
     def as_string(self):
         key = self._get_key()

--- a/tests/cli/cff_1_0_3/apalike.txt
+++ b/tests/cli/cff_1_0_3/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/cli/cff_1_0_3/apalike.txt
+++ b/tests/cli/cff_1_0_3/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/cli/cff_1_0_3/apalike.txt
+++ b/tests/cli/cff_1_0_3/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., & Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/cli/cff_1_1_0/apalike.txt
+++ b/tests/cli/cff_1_1_0/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/cli/cff_1_1_0/apalike.txt
+++ b/tests/cli/cff_1_1_0/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/cli/cff_1_1_0/apalike.txt
+++ b/tests/cli/cff_1_1_0/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., & Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/cli/cff_1_2_0/apalike.txt
+++ b/tests/cli/cff_1_2_0/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/from-doi
+Test author. Test title. DOI: 10.0000/from-doi

--- a/tests/cli/cff_1_3_0/apalike.txt
+++ b/tests/cli/cff_1_3_0/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/from-doi
+Test author. Test title. DOI: 10.0000/from-doi

--- a/tests/lib/cff_1_0_3/a/apalike.txt
+++ b/tests/lib/cff_1_0_3/a/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/a/apalike.txt
+++ b/tests/lib/cff_1_0_3/a/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/a/apalike.txt
+++ b/tests/lib/cff_1_0_3/a/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., & Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/a/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/a/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_0_3/a/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/a/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/a/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/a/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/a/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/a/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
+        assert apalike_object().add_author().author == "Spaaks, J. H., & Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/b/apalike.txt
+++ b/tests/lib/cff_1_0_3/b/apalike.txt
@@ -1,1 +1,1 @@
-Fernández de Córdoba Jr. G. (1999). example title (version 1.0.0).
+Fernández de Córdoba Jr., G. (1999). example title (version 1.0.0).

--- a/tests/lib/cff_1_0_3/b/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/b/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "example title"
+        assert apalike_object().add_title().title == "example title (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(1999)."

--- a/tests/lib/cff_1_0_3/b/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/b/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Fernández de Córdoba Jr. G."
+        assert apalike_object().add_author().author == "Fernández de Córdoba Jr., G."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/c/apalike.txt
+++ b/tests/lib/cff_1_0_3/c/apalike.txt
@@ -1,1 +1,1 @@
-Attema J. and Diblen F. (2017). spot (version 0.1.0). DOI: 10.5281/zenodo.1003346 URL: https://github.com/NLeSC/spot
+Attema, J. and Diblen, F. (2017). spot (version 0.1.0). DOI: 10.5281/zenodo.1003346 URL: https://github.com/NLeSC/spot

--- a/tests/lib/cff_1_0_3/c/apalike.txt
+++ b/tests/lib/cff_1_0_3/c/apalike.txt
@@ -1,1 +1,1 @@
-Attema, J. and Diblen, F. (2017). spot (version 0.1.0). DOI: 10.5281/zenodo.1003346 URL: https://github.com/NLeSC/spot
+Attema, J., & Diblen, F. (2017). spot (version 0.1.0). DOI: 10.5281/zenodo.1003346 URL: https://github.com/NLeSC/spot

--- a/tests/lib/cff_1_0_3/c/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/c/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1003346"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "spot"
+        assert apalike_object().add_title().title == "spot (version 0.1.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/NLeSC/spot"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 0.1.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2017)."

--- a/tests/lib/cff_1_0_3/c/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/c/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Attema J. and Diblen F."
+        assert apalike_object().add_author().author == "Attema, J. and Diblen, F."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/c/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/c/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Attema, J. and Diblen, F."
+        assert apalike_object().add_author().author == "Attema, J., & Diblen, F."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/d/apalike.txt
+++ b/tests/lib/cff_1_0_3/d/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., Verhoeven S., and Druskat S. (2018). cffconvert (version 1.0.1). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H., Klaver T., Verhoeven S., and Druskat S. (2018). cffconvert (version 1.0.1). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/d/apalike.txt
+++ b/tests/lib/cff_1_0_3/d/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H., Klaver, T., Verhoeven, S., and Druskat, S. (2018). cffconvert (version 1.0.1). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., Klaver, T., Verhoeven, S., & Druskat, S. (2018). cffconvert (version 1.0.1). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/d/apalike.txt
+++ b/tests/lib/cff_1_0_3/d/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H., Klaver T., Verhoeven S., and Druskat S. (2018). cffconvert (version 1.0.1). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., Klaver, T., Verhoeven, S., and Druskat, S. (2018). cffconvert (version 1.0.1). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/d/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/d/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.1)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.1)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_0_3/d/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/d/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., Verhoeven S., and Druskat S."
+        assert apalike_object().add_author().author == "Spaaks J. H., Klaver T., Verhoeven S., and Druskat S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/d/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/d/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H., Klaver T., Verhoeven S., and Druskat S."
+        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., Verhoeven, S., and Druskat, S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/d/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/d/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., Verhoeven, S., and Druskat, S."
+        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., Verhoeven, S., & Druskat, S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/e/apalike.txt
+++ b/tests/lib/cff_1_0_3/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H., Klaver, T., and Verhoeven, S. (2018). cffconvert (version 0.0.4). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., Klaver, T., & Verhoeven, S. (2018). cffconvert (version 0.0.4). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/e/apalike.txt
+++ b/tests/lib/cff_1_0_3/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., and Verhoeven S. (2018). cffconvert (version 0.0.4). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H., Klaver T., and Verhoeven S. (2018). cffconvert (version 0.0.4). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/e/apalike.txt
+++ b/tests/lib/cff_1_0_3/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H., Klaver T., and Verhoeven S. (2018). cffconvert (version 0.0.4). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., Klaver, T., and Verhoeven, S. (2018). cffconvert (version 0.0.4). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_0_3/e/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/e/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 0.0.4)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 0.0.4)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_0_3/e/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/e/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., and Verhoeven, S."
+        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., & Verhoeven, S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/e/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/e/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and Verhoeven S."
+        assert apalike_object().add_author().author == "Spaaks J. H., Klaver T., and Verhoeven S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_0_3/e/test_apalike_object.py
+++ b/tests/lib/cff_1_0_3/e/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H., Klaver T., and Verhoeven S."
+        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., and Verhoeven, S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/a/apalike.txt
+++ b/tests/lib/cff_1_1_0/a/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/a/apalike.txt
+++ b/tests/lib/cff_1_1_0/a/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/a/apalike.txt
+++ b/tests/lib/cff_1_1_0/a/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., & Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/a/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/a/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_1_0/a/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/a/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/a/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/a/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/a/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/a/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
+        assert apalike_object().add_author().author == "Spaaks, J. H., & Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/b/apalike.txt
+++ b/tests/lib/cff_1_1_0/b/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/b/apalike.txt
+++ b/tests/lib/cff_1_1_0/b/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/b/apalike.txt
+++ b/tests/lib/cff_1_1_0/b/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., & Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/b/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/b/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_1_0/b/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/b/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/b/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/b/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/b/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/b/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
+        assert apalike_object().add_author().author == "Spaaks, J. H., & Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/c/apalike.txt
+++ b/tests/lib/cff_1_1_0/c/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/c/apalike.txt
+++ b/tests/lib/cff_1_1_0/c/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/c/apalike.txt
+++ b/tests/lib/cff_1_1_0/c/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., & Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/c/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/c/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_1_0/c/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/c/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/c/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/c/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/c/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/c/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
+        assert apalike_object().add_author().author == "Spaaks, J. H., & Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/d/apalike.txt
+++ b/tests/lib/cff_1_1_0/d/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/d/apalike.txt
+++ b/tests/lib/cff_1_1_0/d/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/d/apalike.txt
+++ b/tests/lib/cff_1_1_0/d/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., & Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/d/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/d/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_1_0/d/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/d/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/d/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/d/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/d/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/d/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
+        assert apalike_object().add_author().author == "Spaaks, J. H., & Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/e/apalike.txt
+++ b/tests/lib/cff_1_1_0/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., and mysteryauthor (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H., Klaver T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/e/apalike.txt
+++ b/tests/lib/cff_1_1_0/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H., Klaver T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., Klaver, T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/e/apalike.txt
+++ b/tests/lib/cff_1_1_0/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H., Klaver, T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., Klaver, T., & mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/e/apalike.txt
+++ b/tests/lib/cff_1_1_0/e/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H., Klaver T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/e/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/e/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and mysteryauthor"
+        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and mysteryauthor."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_1_0/e/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/e/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and mysteryauthor."
+        assert apalike_object().add_author().author == "Spaaks J. H., Klaver T., and mysteryauthor."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/e/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/e/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., and mysteryauthor."
+        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., & mysteryauthor."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/e/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/e/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H., Klaver T., and mysteryauthor."
+        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., and mysteryauthor."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/f/apalike.txt
+++ b/tests/lib/cff_1_1_0/f/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/f/apalike.txt
+++ b/tests/lib/cff_1_1_0/f/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H. and Klaver T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/f/apalike.txt
+++ b/tests/lib/cff_1_1_0/f/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H. and Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., & Klaver, T. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/f/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/f/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_1_0/f/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/f/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/f/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/f/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H. and Klaver T."
+        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/f/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/f/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H. and Klaver, T."
+        assert apalike_object().add_author().author == "Spaaks, J. H., & Klaver, T."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/g/apalike.txt
+++ b/tests/lib/cff_1_1_0/g/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., and mysteryauthor (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J.H., Klaver T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/g/apalike.txt
+++ b/tests/lib/cff_1_1_0/g/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J. H., Klaver T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., Klaver, T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/g/apalike.txt
+++ b/tests/lib/cff_1_1_0/g/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks, J. H., Klaver, T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks, J. H., Klaver, T., & mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/g/apalike.txt
+++ b/tests/lib/cff_1_1_0/g/apalike.txt
@@ -1,1 +1,1 @@
-Spaaks J.H., Klaver T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert
+Spaaks J. H., Klaver T., and mysteryauthor. (2018). cffconvert (version 1.0.0). DOI: 10.5281/zenodo.1162057 URL: https://github.com/citation-file-format/cffconvert

--- a/tests/lib/cff_1_1_0/g/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/g/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and mysteryauthor"
+        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and mysteryauthor."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.5281/zenodo.1162057"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/citation-file-format/cffconvert"
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_1_0/g/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/g/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J.H., Klaver T., and mysteryauthor."
+        assert apalike_object().add_author().author == "Spaaks J. H., Klaver T., and mysteryauthor."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/g/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/g/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., and mysteryauthor."
+        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., & mysteryauthor."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/g/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/g/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Spaaks J. H., Klaver T., and mysteryauthor."
+        assert apalike_object().add_author().author == "Spaaks, J. H., Klaver, T., and mysteryauthor."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/h/apalike.txt
+++ b/tests/lib/cff_1_1_0/h/apalike.txt
@@ -1,1 +1,1 @@
-Van Zandt, S. and van Zandt, S. (2018). cffconvert (version 1.0.0).
+Van Zandt, S., & van Zandt, S. (2018). cffconvert (version 1.0.0).

--- a/tests/lib/cff_1_1_0/h/apalike.txt
+++ b/tests/lib/cff_1_1_0/h/apalike.txt
@@ -1,1 +1,1 @@
-Van Zandt S. and van Zandt S. (2018). cffconvert (version 1.0.0).
+Van Zandt, S. and van Zandt, S. (2018). cffconvert (version 1.0.0).

--- a/tests/lib/cff_1_1_0/h/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/h/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "cffconvert"
+        assert apalike_object().add_title().title == "cffconvert (version 1.0.0)."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version == "(version 1.0.0)."
 
     def test_year(self):
         assert apalike_object().add_year().year == "(2018)."

--- a/tests/lib/cff_1_1_0/h/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/h/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Van Zandt, S. and van Zandt, S."
+        assert apalike_object().add_author().author == "Van Zandt, S., & van Zandt, S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_1_0/h/test_apalike_object.py
+++ b/tests/lib/cff_1_1_0/h/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Van Zandt S. and van Zandt S."
+        assert apalike_object().add_author().author == "Van Zandt, S. and van Zandt, S."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J.H. the title
+von der Spaaks Jr. J.H. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J. H. the title.
+von der Spaaks Jr., J. H. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J.H. the title.
+von der Spaaks Jr. J. H. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "von der Spaaks Jr. J. H."
+        assert apalike_object().add_author().author == "von der Spaaks Jr., J. H."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "von der Spaaks Jr. J.H."
+        assert apalike_object().add_author().author == "von der Spaaks Jr. J. H."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J.H. the title
+von der Spaaks Jr. J.H. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J. H. the title.
+von der Spaaks Jr., J. H. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J.H. the title.
+von der Spaaks Jr. J. H. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "von der Spaaks Jr. J. H."
+        assert apalike_object().add_author().author == "von der Spaaks Jr., J. H."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "von der Spaaks Jr. J.H."
+        assert apalike_object().add_author().author == "von der Spaaks Jr. J. H."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. the title
+van der Vaart III R. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. the title.
+van der Vaart III, R. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GFA____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III R."
+        assert apalike_object().add_author().author == "van der Vaart III, R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. the title
+van der Vaart III R. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. the title.
+van der Vaart III, R. the title.

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/GF_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III R."
+        assert apalike_object().add_author().author == "van der Vaart III, R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/apalike.txt
@@ -1,1 +1,1 @@
-Rafael the title
+Rafael. the title.

--- a/tests/lib/cff_1_2_0/authors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G_A____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Rafael"
+        assert apalike_object().add_author().author == "Rafael."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/G______/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/G______/apalike.txt
@@ -1,1 +1,1 @@
-Rafael the title
+Rafael. the title.

--- a/tests/lib/cff_1_2_0/authors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/G______/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Rafael"
+        assert apalike_object().add_author().author == "Rafael."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III the title
+van der Vaart III. the title.

--- a/tests/lib/cff_1_2_0/authors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_FA____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III"
+        assert apalike_object().add_author().author == "van der Vaart III."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III the title
+van der Vaart III. the title.

--- a/tests/lib/cff_1_2_0/authors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/_F_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III"
+        assert apalike_object().add_author().author == "van der Vaart III."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/apalike.txt
@@ -1,1 +1,1 @@
-The soccer team members the title
+The soccer team members. the title.

--- a/tests/lib/cff_1_2_0/authors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/__AN___/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The soccer team members"
+        assert apalike_object().add_author().author == "The soccer team members."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/one/___N___/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/apalike.txt
@@ -1,1 +1,1 @@
-The soccer team members the title
+The soccer team members. the title.

--- a/tests/lib/cff_1_2_0/authors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/one/___N___/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The soccer team members"
+        assert apalike_object().add_author().author == "The soccer team members."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. and dos Santos Aveiro C.R. the title
+van der Vaart III R. and dos Santos Aveiro C.R. the title.

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. and dos Santos Aveiro C.R. the title.
+van der Vaart III, R. and dos Santos Aveiro, C. R. the title.

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III, R. and dos Santos Aveiro, C. R. the title.
+van der Vaart III, R., & dos Santos Aveiro, C. R. the title.

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III R. and dos Santos Aveiro C.R."
+        assert apalike_object().add_author().author == "van der Vaart III, R. and dos Santos Aveiro, C. R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/authors/two/GF_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III, R. and dos Santos Aveiro, C. R."
+        assert apalike_object().add_author().author == "van der Vaart III, R., & dos Santos Aveiro, C. R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_2_0/identifiers/DI/apalike.txt
+++ b/tests/lib/cff_1_2_0/identifiers/DI/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/from-identifiers
+Test author. Test title. DOI: 10.0000/from-identifiers

--- a/tests/lib/cff_1_2_0/identifiers/DI/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.0000/from-identifiers"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/apalike.txt
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/some-doi
+Test author. Test title. DOI: 10.0000/some-doi

--- a/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/DI_duplicate_values/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.0000/some-doi"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/identifiers/D_/apalike.txt
+++ b/tests/lib/cff_1_2_0/identifiers/D_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/from-doi
+Test author. Test title. DOI: 10.0000/from-doi

--- a/tests/lib/cff_1_2_0/identifiers/D_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/D_/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.0000/from-doi"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/identifiers/_I/apalike.txt
+++ b/tests/lib/cff_1_2_0/identifiers/_I/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/from-identifiers
+Test author. Test title. DOI: 10.0000/from-identifiers

--- a/tests/lib/cff_1_2_0/identifiers/_I/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/_I/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.0000/from-identifiers"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/identifiers/__/apalike.txt
+++ b/tests/lib/cff_1_2_0/identifiers/__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title
+Test author. Test title.

--- a/tests/lib/cff_1_2_0/identifiers/__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/identifiers/__/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/types/dataset/apalike.txt
+++ b/tests/lib/cff_1_2_0/types/dataset/apalike.txt
@@ -1,0 +1,1 @@
+The name. The title [Data set].

--- a/tests/lib/cff_1_2_0/types/dataset/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/types/dataset/test_apalike_object.py
@@ -1,0 +1,48 @@
+import os
+from functools import lru_cache
+
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
+
+from tests.lib.contracts.apalike import Contract
+
+
+@lru_cache
+def apalike_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ApalikeObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.lib
+@pytest.mark.apalike
+class TestApalikeObject(Contract):
+
+    def test_as_string(self):
+        actual_apalike = apalike_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_apalike = f.read()
+        assert actual_apalike == expected_apalike
+
+    def test_author(self):
+        assert apalike_object().add_author().author == "The name."
+
+    def test_check_cffobj(self):
+        apalike_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert apalike_object().add_doi().doi is None
+
+    def test_title(self):
+        assert apalike_object().add_title().title == "The title [Data set]."
+
+    def test_url(self):
+        assert apalike_object().add_url().url is None
+
+    def test_year(self):
+        assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/types/dataset/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/types/dataset/test_apalike_object.py
@@ -1,10 +1,8 @@
 import os
 from functools import lru_cache
-
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
-
 from tests.lib.contracts.apalike import Contract
 
 

--- a/tests/lib/cff_1_2_0/types/none/apalike.txt
+++ b/tests/lib/cff_1_2_0/types/none/apalike.txt
@@ -1,0 +1,1 @@
+The name. The title.

--- a/tests/lib/cff_1_2_0/types/none/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/types/none/test_apalike_object.py
@@ -1,0 +1,48 @@
+import os
+from functools import lru_cache
+
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
+
+from tests.lib.contracts.apalike import Contract
+
+
+@lru_cache
+def apalike_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ApalikeObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.lib
+@pytest.mark.apalike
+class TestApalikeObject(Contract):
+
+    def test_as_string(self):
+        actual_apalike = apalike_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_apalike = f.read()
+        assert actual_apalike == expected_apalike
+
+    def test_author(self):
+        assert apalike_object().add_author().author == "The name."
+
+    def test_check_cffobj(self):
+        apalike_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert apalike_object().add_doi().doi is None
+
+    def test_title(self):
+        assert apalike_object().add_title().title == "The title."
+
+    def test_url(self):
+        assert apalike_object().add_url().url is None
+
+    def test_year(self):
+        assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/types/none/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/types/none/test_apalike_object.py
@@ -1,10 +1,8 @@
 import os
 from functools import lru_cache
-
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
-
 from tests.lib.contracts.apalike import Contract
 
 

--- a/tests/lib/cff_1_2_0/types/software/apalike.txt
+++ b/tests/lib/cff_1_2_0/types/software/apalike.txt
@@ -1,0 +1,1 @@
+The name. The title [Computer software].

--- a/tests/lib/cff_1_2_0/types/software/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/types/software/test_apalike_object.py
@@ -1,0 +1,48 @@
+import os
+from functools import lru_cache
+
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
+
+from tests.lib.contracts.apalike import Contract
+
+
+@lru_cache
+def apalike_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ApalikeObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.lib
+@pytest.mark.apalike
+class TestApalikeObject(Contract):
+
+    def test_as_string(self):
+        actual_apalike = apalike_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_apalike = f.read()
+        assert actual_apalike == expected_apalike
+
+    def test_author(self):
+        assert apalike_object().add_author().author == "The name."
+
+    def test_check_cffobj(self):
+        apalike_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert apalike_object().add_doi().doi is None
+
+    def test_title(self):
+        assert apalike_object().add_title().title == "The title [Computer software]."
+
+    def test_url(self):
+        assert apalike_object().add_url().url is None
+
+    def test_year(self):
+        assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/types/software/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/types/software/test_apalike_object.py
@@ -1,10 +1,8 @@
 import os
 from functools import lru_cache
-
 import pytest
 from cffconvert import Citation
 from cffconvert.lib.cff_1_2_x.apalike import ApalikeObject
-
 from tests.lib.contracts.apalike import Contract
 
 

--- a/tests/lib/cff_1_2_0/urls/IRACU/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/IRACU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/IRACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRACU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/IRAC_/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/IRAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRAC_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/IRA_U/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/IRA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA_U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/IRA__/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/IRA__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/IRA__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IRA__/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/IR_CU/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/IR_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_CU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/IR_C_/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/IR_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR_C_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/IR__U/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/IR__U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/IR__U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR__U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/IR___/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/IR___/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/IR___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/IR___/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/I_ACU/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/I_ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_ACU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/I_AC_/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/I_AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_AC_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/I_A_U/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/I_A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A_U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/I_A__/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/I_A__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/I_A__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I_A__/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/I__CU/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/I__CU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/I__CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__CU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/I__C_/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/I__C_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/I__C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I__C_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/I___U/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/I___U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/I___U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I___U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/I____/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/I____/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_2_0/urls/I____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/I____/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_RACU/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_RACU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_2_0/urls/_RACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RACU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_RAC_/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-code
+Test author. Test title. URL: https://github.com/the-url-from-repository-code

--- a/tests/lib/cff_1_2_0/urls/_RAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RAC_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-code"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_RA_U/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_2_0/urls/_RA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA_U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_RA__/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_RA__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository
+Test author. Test title. URL: https://github.com/the-url-from-repository

--- a/tests/lib/cff_1_2_0/urls/_RA__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_RA__/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_R_CU/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_2_0/urls/_R_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_CU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_R_C_/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-code
+Test author. Test title. URL: https://github.com/the-url-from-repository-code

--- a/tests/lib/cff_1_2_0/urls/_R_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R_C_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-code"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_R__U/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_R__U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_2_0/urls/_R__U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R__U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_R___/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_R___/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository
+Test author. Test title. URL: https://github.com/the-url-from-repository

--- a/tests/lib/cff_1_2_0/urls/_R___/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_R___/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/__ACU/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/__ACU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_2_0/urls/__ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__ACU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/__AC_/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/__AC_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-code
+Test author. Test title. URL: https://github.com/the-url-from-repository-code

--- a/tests/lib/cff_1_2_0/urls/__AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__AC_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-code"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/__A_U/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/__A_U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_2_0/urls/__A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A_U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/__A__/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/__A__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-artifact
+Test author. Test title. URL: https://github.com/the-url-from-repository-artifact

--- a/tests/lib/cff_1_2_0/urls/__A__/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/__A__/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-artifact"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/___CU/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/___CU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_2_0/urls/___CU/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/___CU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/___C_/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/___C_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-code
+Test author. Test title. URL: https://github.com/the-url-from-repository-code

--- a/tests/lib/cff_1_2_0/urls/___C_/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/___C_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-code"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/____U/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/____U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_2_0/urls/____U/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/____U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_2_0/urls/_____/apalike.txt
+++ b/tests/lib/cff_1_2_0/urls/_____/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title
+Test author. Test title.

--- a/tests/lib/cff_1_2_0/urls/_____/test_apalike_object.py
+++ b/tests/lib/cff_1_2_0/urls/_____/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J.H. the title
+von der Spaaks Jr. J.H. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J. H. the title.
+von der Spaaks Jr., J. H. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J.H. the title.
+von der Spaaks Jr. J. H. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "von der Spaaks Jr. J. H."
+        assert apalike_object().add_author().author == "von der Spaaks Jr., J. H."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AOE/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "von der Spaaks Jr. J.H."
+        assert apalike_object().add_author().author == "von der Spaaks Jr. J. H."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J.H. the title
+von der Spaaks Jr. J.H. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J. H. the title.
+von der Spaaks Jr., J. H. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/apalike.txt
@@ -1,1 +1,1 @@
-von der Spaaks Jr. J.H. the title.
+von der Spaaks Jr. J. H. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "von der Spaaks Jr. J. H."
+        assert apalike_object().add_author().author == "von der Spaaks Jr., J. H."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA_AO_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "von der Spaaks Jr. J.H."
+        assert apalike_object().add_author().author == "von der Spaaks Jr. J. H."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. the title
+van der Vaart III R. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. the title.
+van der Vaart III, R. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GFA____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III R."
+        assert apalike_object().add_author().author == "van der Vaart III, R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. the title
+van der Vaart III R. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. the title.
+van der Vaart III, R. the title.

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/GF_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III R."
+        assert apalike_object().add_author().author == "van der Vaart III, R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/apalike.txt
@@ -1,1 +1,1 @@
-Rafael the title
+Rafael. the title.

--- a/tests/lib/cff_1_3_0/authors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G_A____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Rafael"
+        assert apalike_object().add_author().author == "Rafael."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/G______/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/G______/apalike.txt
@@ -1,1 +1,1 @@
-Rafael the title
+Rafael. the title.

--- a/tests/lib/cff_1_3_0/authors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/G______/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Rafael"
+        assert apalike_object().add_author().author == "Rafael."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III the title
+van der Vaart III. the title.

--- a/tests/lib/cff_1_3_0/authors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_FA____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III"
+        assert apalike_object().add_author().author == "van der Vaart III."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III the title
+van der Vaart III. the title.

--- a/tests/lib/cff_1_3_0/authors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/_F_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III"
+        assert apalike_object().add_author().author == "van der Vaart III."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/apalike.txt
@@ -1,1 +1,1 @@
-The soccer team members the title
+The soccer team members. the title.

--- a/tests/lib/cff_1_3_0/authors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__AN___/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The soccer team members"
+        assert apalike_object().add_author().author == "The soccer team members."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/__A____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/apalike.txt
@@ -1,1 +1,1 @@
-Rafa the title
+Rafa. the title.

--- a/tests/lib/cff_1_3_0/authors/one/__A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/__A____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Rafa"
+        assert apalike_object().add_author().author == "Rafa."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/one/___N___/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/apalike.txt
@@ -1,1 +1,1 @@
-The soccer team members the title
+The soccer team members. the title.

--- a/tests/lib/cff_1_3_0/authors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/one/___N___/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The soccer team members"
+        assert apalike_object().add_author().author == "The soccer team members."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. and dos Santos Aveiro C.R. the title
+van der Vaart III R. and dos Santos Aveiro C.R. the title.

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III R. and dos Santos Aveiro C.R. the title.
+van der Vaart III, R. and dos Santos Aveiro, C. R. the title.

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-van der Vaart III, R. and dos Santos Aveiro, C. R. the title.
+van der Vaart III, R., & dos Santos Aveiro, C. R. the title.

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III R. and dos Santos Aveiro C.R."
+        assert apalike_object().add_author().author == "van der Vaart III, R. and dos Santos Aveiro, C. R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/authors/two/GF_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "van der Vaart III, R. and dos Santos Aveiro, C. R."
+        assert apalike_object().add_author().author == "van der Vaart III, R., & dos Santos Aveiro, C. R."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AOE/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA_AO_/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/GFA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GFA____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/GF_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/G_A____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G_A____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/G______/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/G______/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/G______/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/_FA____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_FA____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/_F_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/_F_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/__AN___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/__AN___/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/one/___N___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/one/___N___/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/apalike.txt
@@ -1,1 +1,1 @@
-The author the title
+The author. the title.

--- a/tests/lib/cff_1_3_0/contributors/two/GF_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/contributors/two/GF_____/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "The author"
+        assert apalike_object().add_author().author == "The author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "the title"
+        assert apalike_object().add_title().title == "the title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/apalike.txt
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/from-identifiers
+Test author. Test title. DOI: 10.0000/from-identifiers

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.0000/from-identifiers"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/apalike.txt
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/some-doi
+Test author. Test title. DOI: 10.0000/some-doi

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_dois/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.0000/some-doi"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/apalike.txt
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/somewhere
+Test author. Test title. URL: https://github.com/somewhere

--- a/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/DI_duplicate_urls/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/somewhere"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/apalike.txt
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/from-doi
+Test author. Test title. DOI: 10.0000/from-doi

--- a/tests/lib/cff_1_3_0/identifiers/sources/D_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/D_/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.0000/from-doi"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/apalike.txt
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title DOI: 10.0000/from-identifiers
+Test author. Test title. DOI: 10.0000/from-identifiers

--- a/tests/lib/cff_1_3_0/identifiers/sources/_I/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/_I/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi == "DOI: 10.0000/from-identifiers"
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/apalike.txt
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title
+Test author. Test title.

--- a/tests/lib/cff_1_3_0/identifiers/sources/__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/identifiers/sources/__/test_apalike_object.py
@@ -27,7 +27,7 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert apalike_object().add_doi().doi is None
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/types/dataset/apalike.txt
+++ b/tests/lib/cff_1_3_0/types/dataset/apalike.txt
@@ -1,0 +1,1 @@
+The name. The title [Data set].

--- a/tests/lib/cff_1_3_0/types/dataset/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/types/dataset/test_apalike_object.py
@@ -1,0 +1,46 @@
+import os
+from functools import lru_cache
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
+from tests.lib.contracts.apalike import Contract
+
+
+@lru_cache
+def apalike_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ApalikeObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.lib
+@pytest.mark.apalike
+class TestApalikeObject(Contract):
+
+    def test_as_string(self):
+        actual_apalike = apalike_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_apalike = f.read()
+        assert actual_apalike == expected_apalike
+
+    def test_author(self):
+        assert apalike_object().add_author().author == "The name."
+
+    def test_doi(self):
+        assert apalike_object().add_doi().doi is None
+
+    def test_check_cffobj(self):
+        apalike_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_title(self):
+        assert apalike_object().add_title().title == "The title [Data set]."
+
+    def test_url(self):
+        assert apalike_object().add_url().url is None
+
+    def test_year(self):
+        assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/types/none/apalike.txt
+++ b/tests/lib/cff_1_3_0/types/none/apalike.txt
@@ -1,0 +1,1 @@
+The name. The title.

--- a/tests/lib/cff_1_3_0/types/none/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/types/none/test_apalike_object.py
@@ -1,0 +1,46 @@
+import os
+from functools import lru_cache
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
+from tests.lib.contracts.apalike import Contract
+
+
+@lru_cache
+def apalike_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ApalikeObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.lib
+@pytest.mark.apalike
+class TestApalikeObject(Contract):
+
+    def test_as_string(self):
+        actual_apalike = apalike_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_apalike = f.read()
+        assert actual_apalike == expected_apalike
+
+    def test_author(self):
+        assert apalike_object().add_author().author == "The name."
+
+    def test_check_cffobj(self):
+        apalike_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert apalike_object().add_doi().doi is None
+
+    def test_title(self):
+        assert apalike_object().add_title().title == "The title."
+
+    def test_url(self):
+        assert apalike_object().add_url().url is None
+
+    def test_year(self):
+        assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/types/software/apalike.txt
+++ b/tests/lib/cff_1_3_0/types/software/apalike.txt
@@ -1,0 +1,1 @@
+The name. The title [Computer software].

--- a/tests/lib/cff_1_3_0/types/software/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/types/software/test_apalike_object.py
@@ -1,0 +1,46 @@
+import os
+from functools import lru_cache
+import pytest
+from cffconvert import Citation
+from cffconvert.lib.cff_1_3_x.apalike import ApalikeObject
+from tests.lib.contracts.apalike import Contract
+
+
+@lru_cache
+def apalike_object():
+    fixture = os.path.join(os.path.dirname(__file__), "CITATION.cff")
+    with open(fixture, "rt", encoding="utf-8") as f:
+        cffstr = f.read()
+        citation = Citation(cffstr)
+        return ApalikeObject(citation.cffobj, initialize_empty=True)
+
+
+@pytest.mark.lib
+@pytest.mark.apalike
+class TestApalikeObject(Contract):
+
+    def test_as_string(self):
+        actual_apalike = apalike_object().add_all().as_string()
+        fixture = os.path.join(os.path.dirname(__file__), "apalike.txt")
+        with open(fixture, "rt", encoding="utf-8") as f:
+            expected_apalike = f.read()
+        assert actual_apalike == expected_apalike
+
+    def test_author(self):
+        assert apalike_object().add_author().author == "The name."
+
+    def test_check_cffobj(self):
+        apalike_object().check_cffobj()
+        # doesn't need an assert
+
+    def test_doi(self):
+        assert apalike_object().add_doi().doi is None
+
+    def test_title(self):
+        assert apalike_object().add_title().title == "The title [Computer software]."
+
+    def test_url(self):
+        assert apalike_object().add_url().url is None
+
+    def test_year(self):
+        assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/IRACU/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/IRACU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/IRACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRACU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/IRAC_/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/IRAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRAC_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/IRA_U/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/IRA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA_U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/IRA__/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/IRA__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/IRA__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IRA__/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/IR_CU/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/IR_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_CU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/IR_C_/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/IR_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR_C_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/IR__U/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/IR__U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/IR__U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR__U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/IR___/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/IR___/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/IR___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/IR___/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/I_ACU/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/I_ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_ACU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/I_AC_/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/I_AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_AC_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/I_A_U/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/I_A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A_U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/I_A__/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/I_A__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/I_A__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I_A__/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/I__CU/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/I__CU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/I__CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__CU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/I__C_/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/I__C_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/I__C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I__C_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/I___U/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/I___U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/I___U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I___U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/I____/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/I____/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-identifiers
+Test author. Test title. URL: https://github.com/the-url-from-identifiers

--- a/tests/lib/cff_1_3_0/urls/I____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/I____/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-identifiers"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_RACU/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_RACU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_3_0/urls/_RACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RACU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_RAC_/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-code
+Test author. Test title. URL: https://github.com/the-url-from-repository-code

--- a/tests/lib/cff_1_3_0/urls/_RAC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RAC_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-code"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_RA_U/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_3_0/urls/_RA_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA_U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_RA__/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_RA__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository
+Test author. Test title. URL: https://github.com/the-url-from-repository

--- a/tests/lib/cff_1_3_0/urls/_RA__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_RA__/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_R_CU/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_3_0/urls/_R_CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_CU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_R_C_/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-code
+Test author. Test title. URL: https://github.com/the-url-from-repository-code

--- a/tests/lib/cff_1_3_0/urls/_R_C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R_C_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-code"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_R__U/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_R__U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_3_0/urls/_R__U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R__U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_R___/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_R___/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository
+Test author. Test title. URL: https://github.com/the-url-from-repository

--- a/tests/lib/cff_1_3_0/urls/_R___/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_R___/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/__ACU/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/__ACU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_3_0/urls/__ACU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__ACU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/__AC_/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/__AC_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-code
+Test author. Test title. URL: https://github.com/the-url-from-repository-code

--- a/tests/lib/cff_1_3_0/urls/__AC_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__AC_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-code"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/__A_U/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/__A_U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_3_0/urls/__A_U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A_U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/__A__/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/__A__/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-artifact
+Test author. Test title. URL: https://github.com/the-url-from-repository-artifact

--- a/tests/lib/cff_1_3_0/urls/__A__/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/__A__/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-artifact"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/___CU/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/___CU/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_3_0/urls/___CU/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/___CU/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/___C_/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/___C_/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-repository-code
+Test author. Test title. URL: https://github.com/the-url-from-repository-code

--- a/tests/lib/cff_1_3_0/urls/___C_/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/___C_/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-repository-code"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/____U/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/____U/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title URL: https://github.com/the-url-from-url
+Test author. Test title. URL: https://github.com/the-url-from-url

--- a/tests/lib/cff_1_3_0/urls/____U/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/____U/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url == "URL: https://github.com/the-url-from-url"
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/cff_1_3_0/urls/_____/apalike.txt
+++ b/tests/lib/cff_1_3_0/urls/_____/apalike.txt
@@ -1,1 +1,1 @@
-Test author Test title
+Test author. Test title.

--- a/tests/lib/cff_1_3_0/urls/_____/test_apalike_object.py
+++ b/tests/lib/cff_1_3_0/urls/_____/test_apalike_object.py
@@ -20,7 +20,7 @@ def apalike_object():
 class TestApalikeObject(Contract):
 
     def test_author(self):
-        assert apalike_object().add_author().author == "Test author"
+        assert apalike_object().add_author().author == "Test author."
 
     def test_check_cffobj(self):
         apalike_object().check_cffobj()
@@ -37,13 +37,10 @@ class TestApalikeObject(Contract):
         assert actual_apalike == expected_apalike
 
     def test_title(self):
-        assert apalike_object().add_title().title == "Test title"
+        assert apalike_object().add_title().title == "Test title."
 
     def test_url(self):
         assert apalike_object().add_url().url is None
-
-    def test_version(self):
-        assert apalike_object().add_version().version is None
 
     def test_year(self):
         assert apalike_object().add_year().year is None

--- a/tests/lib/contracts/apalike.py
+++ b/tests/lib/contracts/apalike.py
@@ -29,9 +29,5 @@ class Contract(ABC):
         pass
 
     @abstractmethod
-    def test_version(self):
-        pass
-
-    @abstractmethod
     def test_year(self):
         pass


### PR DESCRIPTION
This PR drops the `version` property from the `ApalikeObject`, and includes the version along with the now supported `type` in the `title` property. 
All tests have been updated accordingly.
New apalike tests have been added for the cff `type`.

Check all `apalike.txt` files which are now correctly following APA style.

closes #406
